### PR TITLE
Fix registration of CRS in HTML view

### DIFF
--- a/deegree-ogcapi-features/src/main/resources/collection.html
+++ b/deegree-ogcapi-features/src/main/resources/collection.html
@@ -349,7 +349,7 @@ var map = new ol.Map({
 
 function registerCrs(crsCode, projDef){
    if( crsCode != null &&  projDef != null ) {
-       proj4.defs('EPSG:25832', '+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
+       proj4.defs(crsCode, projDef);
        ol.proj.proj4.register(proj4);
        return true;
    }


### PR DESCRIPTION
Previously, the CRS defined in method registerCrs was hard coded to EPSG:25832.
With this pull request, the value configured in Map element in html/*.xml is registered.
By that, it is possible to change the projection of the map in the collection view (an error occurred when trying to change the CRS before).

Fixes #24.