### PR TITLE
Upgrade dependency of deegree web services API to v3.5.0-SNAPSHOT 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -875,7 +875,7 @@
     <swagger-version>2.1.11</swagger-version>
     <swagger-ui-version>3.52.5</swagger-ui-version>
     <jackson-version>2.12.5</jackson-version>
-    <deegree-version>3.4.26-SNAPSHOT</deegree-version>
+    <deegree-version>3.5.0-SNAPSHOT</deegree-version>
     <slf4j.version>1.7.36</slf4j.version>
     <log4j.version>2.17.1</log4j.version>
   </properties>


### PR DESCRIPTION
This PR upgrades the dependency from deegree OGCAPI to version 3.5.0-SNAPSHOT which is required for GeoJson support.