### PR TITLE
Update configVersion and schemaLocation in documentation to deegree version 3.5

### DIFF
--- a/deegree-ogcapi-config-htmlview/src/main/resources/META-INF/schemas/ogcapi/htmlview/3.4.0/example.xml
+++ b/deegree-ogcapi-config-htmlview/src/main/resources/META-INF/schemas/ogcapi/htmlview/3.4.0/example.xml
@@ -19,8 +19,7 @@
   <http://www.gnu.org/licenses/lgpl-2.1.html>.
   #L%
   -->
-<HtmlView configVersion="3.4.0"
-          xmlns="http://www.deegree.org/services/oaf/htmlviewconfig"
+<HtmlView xmlns="http://www.deegree.org/services/oaf/htmlviewconfig"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://www.deegree.org/services/oaf/htmlviewconfig htmlviewconfig.xsd">
 

--- a/deegree-ogcapi-config-htmlview/src/main/resources/META-INF/schemas/ogcapi/htmlview/3.4.0/htmlview.xsd
+++ b/deegree-ogcapi-config-htmlview/src/main/resources/META-INF/schemas/ogcapi/htmlview/3.4.0/htmlview.xsd
@@ -52,13 +52,7 @@
           </complexType>
         </element>
       </sequence>
-      <attribute name="configVersion" use="required">
-        <simpleType>
-          <restriction base="string">
-            <enumeration value="3.4.0"/>
-          </restriction>
-        </simpleType>
-      </attribute>
+      <attribute name="configVersion" use="optional"/>
     </complexType>
   </element>
 </schema>

--- a/deegree-ogcapi-datasets/src/main/resources/META-INF/schemas/ogcapi/datasets/3.4.0/datasets.xsd
+++ b/deegree-ogcapi-datasets/src/main/resources/META-INF/schemas/ogcapi/datasets/3.4.0/datasets.xsd
@@ -24,13 +24,7 @@
           </complexType>
         </element>
       </sequence>
-      <attribute name="configVersion" use="required">
-        <simpleType>
-          <restriction base="string">
-            <enumeration value="3.4.0"/>
-          </restriction>
-        </simpleType>
-      </attribute>
+      <attribute name="configVersion" use="optional"/>
     </complexType>
   </element>
 

--- a/deegree-ogcapi-datasets/src/main/resources/META-INF/schemas/ogcapi/datasets/3.4.0/example.xml
+++ b/deegree-ogcapi-datasets/src/main/resources/META-INF/schemas/ogcapi/datasets/3.4.0/example.xml
@@ -1,7 +1,6 @@
-<Datasets configVersion="3.4.0"
-                        xmlns="http://www.deegree.org/ogcapi/datasets"
-                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xsi:schemaLocation="http://www.deegree.org/ogcapi/datasets datasets.xsd">
+<Datasets xmlns="http://www.deegree.org/ogcapi/datasets"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.deegree.org/ogcapi/datasets datasets.xsd">
 
   <Title>deegree Datasets</Title>
   <Description>Description of deegree Datasets</Description>

--- a/deegree-ogcapi-documentation/src/main/asciidoc/configuration.adoc
+++ b/deegree-ogcapi-documentation/src/main/asciidoc/configuration.adoc
@@ -86,8 +86,8 @@ To provide general information about the datasets provider the following configu
 ----
 <Datasets xmlns="http://www.deegree.org/ogcapi/datasets"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://www.deegree.org/ogcapi/datasets  http://schemas.deegree.org/3.5/ogcapi/datasets/datasets.xsd"
-          configVersion="3.5.0">
+          xsi:schemaLocation="http://www.deegree.org/ogcapi/datasets  http://schemas.deegree.org/3.5/ogcapi/datasets/datasets.xsd">
+
   <Title>Datasets Title</Title>
   <Description>Datasets Description</Description> <!--1-->
   <Contact>
@@ -133,8 +133,7 @@ Each dataset is configured in a separate file. The following example shows a min
 ----
 <deegreeOAF xmlns="http://www.deegree.org/ogcapi/features"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://www.deegree.org/ogcapi/features http://schemas.deegree.org/3.5/ogcapi/features/features.xsd"
-            configVersion="3.5.0">
+            xsi:schemaLocation="http://www.deegree.org/ogcapi/features http://schemas.deegree.org/3.5/ogcapi/features/features.xsd">
 
   <FeatureStoreId>streets</FeatureStoreId>  <!--1-->
 
@@ -158,9 +157,8 @@ The next example shows a complete configuration for a dataset called "trees" wit
 ----
 <deegreeOAF xmlns="http://www.deegree.org/ogcapi/features"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://www.deegree.org/ogcapi/features http://schemas.deegree.org/3.5/ogcapi/features/features.xsd"
-            configVersion="3.5.0">
-
+            xsi:schemaLocation="http://www.deegree.org/ogcapi/features http://schemas.deegree.org/3.5/ogcapi/features/features.xsd">
+            
   <FeatureStoreId>trees</FeatureStoreId>  <!--1-->
 
   <UseExistingGMLSchema>true</UseExistingGMLSchema> <!--2-->
@@ -262,8 +260,7 @@ The following excerpt of the _streets_metadata.xml_ shows which options are avai
 ----
 <deegreeServicesMetadata xmlns="http://www.deegree.org/services/metadata"
                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://www.deegree.org/services/metadata https://schemas.deegree.org/3.5/services/metadata/metadata.xsd"
-                         configVersion="3.5.0">
+                         xsi:schemaLocation="http://www.deegree.org/services/metadata https://schemas.deegree.org/3.5/services/metadata/metadata.xsd">
 
   <ServiceIdentification> <!--1-->
     <Title>deegree OGC API - Features</Title>
@@ -350,9 +347,8 @@ To configure the HTML encoding a configuration file can be used. The following e
 ----
 <HtmlView xmlns="http://www.deegree.org/ogcapi/htmlview"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://www.deegree.org/ogcapi/htmlview http://schemas.deegree.org/3.5/ogcapi/htmlview/htmlview.xsd"
-          configVersion="3.5.0">
-
+          xsi:schemaLocation="http://www.deegree.org/ogcapi/htmlview http://schemas.deegree.org/3.5/ogcapi/htmlview/htmlview.xsd">
+          
   <CssFile>../html/lgv.css</CssFile>  <!--1-->
   <LegalNoticeUrl>https://www.hamburg.de/legalNotice/</LegalNoticeUrl> <!--2-->
   <PrivacyPolicyUrl>https://www.hamburg.de/datenschutz/</PrivacyPolicyUrl> <!--3-->

--- a/deegree-ogcapi-documentation/src/main/asciidoc/configuration.adoc
+++ b/deegree-ogcapi-documentation/src/main/asciidoc/configuration.adoc
@@ -86,8 +86,8 @@ To provide general information about the datasets provider the following configu
 ----
 <Datasets xmlns="http://www.deegree.org/ogcapi/datasets"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://www.deegree.org/ogcapi/datasets  http://schemas.deegree.org/ogcapi/datasets/3.4.0/datasets.xsd"
-          configVersion="3.4.0">
+          xsi:schemaLocation="http://www.deegree.org/ogcapi/datasets  http://schemas.deegree.org/3.5/ogcapi/datasets/datasets.xsd"
+          configVersion="3.5.0">
   <Title>Datasets Title</Title>
   <Description>Datasets Description</Description> <!--1-->
   <Contact>
@@ -133,8 +133,8 @@ Each dataset is configured in a separate file. The following example shows a min
 ----
 <deegreeOAF xmlns="http://www.deegree.org/ogcapi/features"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://www.deegree.org/ogcapi/features http://schemas.deegree.org/ogcapi/features/3.4.0/features.xsd"
-            configVersion="3.4.0">
+            xsi:schemaLocation="http://www.deegree.org/ogcapi/features http://schemas.deegree.org/3.5/ogcapi/features/features.xsd"
+            configVersion="3.5.0">
 
   <FeatureStoreId>streets</FeatureStoreId>  <!--1-->
 
@@ -158,8 +158,8 @@ The next example shows a complete configuration for a dataset called "trees" wit
 ----
 <deegreeOAF xmlns="http://www.deegree.org/ogcapi/features"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://www.deegree.org/ogcapi/features http://schemas.deegree.org/ogcapi/features/3.4.0/features.xsd"
-            configVersion="3.4.0">
+            xsi:schemaLocation="http://www.deegree.org/ogcapi/features http://schemas.deegree.org/3.5/ogcapi/features/features.xsd"
+            configVersion="3.5.0">
 
   <FeatureStoreId>trees</FeatureStoreId>  <!--1-->
 
@@ -262,8 +262,8 @@ The following excerpt of the _streets_metadata.xml_ shows which options are avai
 ----
 <deegreeServicesMetadata xmlns="http://www.deegree.org/services/metadata"
                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://www.deegree.org/services/metadata http://schemas.deegree.org/services/metadata/3.4.0/metadata.xsd"
-                         configVersion="3.4.0">
+                         xsi:schemaLocation="http://www.deegree.org/services/metadata https://schemas.deegree.org/3.5/services/metadata/metadata.xsd"
+                         configVersion="3.5.0">
 
   <ServiceIdentification> <!--1-->
     <Title>deegree OGC API - Features</Title>
@@ -350,8 +350,8 @@ To configure the HTML encoding a configuration file can be used. The following e
 ----
 <HtmlView xmlns="http://www.deegree.org/ogcapi/htmlview"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://www.deegree.org/ogcapi/htmlview http://schemas.deegree.org/ogcapi/3.4.0/htmlview.xsd"
-          configVersion="3.4.0">
+          xsi:schemaLocation="http://www.deegree.org/ogcapi/htmlview http://schemas.deegree.org/3.5/ogcapi/htmlview/htmlview.xsd"
+          configVersion="3.5.0">
 
   <CssFile>../html/lgv.css</CssFile>  <!--1-->
   <LegalNoticeUrl>https://www.hamburg.de/legalNotice/</LegalNoticeUrl> <!--2-->
@@ -425,4 +425,4 @@ DELETE /config/delete[/path] - delete currently running workspace or file in wor
 The REST-API is enabled by default. To protect this interface from unauthorized use, it is automatically secured with a so-called API key. Each HTTP request requires that the API key contained in the file _config.apikey_ is transferred.
 
 A detailed documentation of the REST-API interface and how access is configured is described in section "deegree REST interface"
-of the https://download.deegree.org/documentation/3.4.17/html/#anchor-configuration-restapi[deegree webservices handbook].
+of the https://download.deegree.org/documentation/current/html/#anchor-configuration-restapi[deegree webservices handbook].

--- a/deegree-ogcapi-features/src/main/resources/META-INF/schemas/ogcapi/features/3.4.0/example.xml
+++ b/deegree-ogcapi-features/src/main/resources/META-INF/schemas/ogcapi/features/3.4.0/example.xml
@@ -1,7 +1,6 @@
-<deegreeOAF configVersion="3.4.0"
-            xmlns="http://www.deegree.org/ogcapi/features"
+<deegreeOAF xmlns="http://www.deegree.org/ogcapi/features"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://www.deegree.org/ogcapi/features oaf_configuration.xsd">
+            xsi:schemaLocation="http://www.deegree.org/ogcapi/features features.xsd">
 
   <FeatureStoreId>test</FeatureStoreId>
 

--- a/deegree-ogcapi-features/src/main/resources/META-INF/schemas/ogcapi/features/3.4.0/features.xsd
+++ b/deegree-ogcapi-features/src/main/resources/META-INF/schemas/ogcapi/features/3.4.0/features.xsd
@@ -26,13 +26,7 @@
         <element name="HtmlViewId" type="string" minOccurs="0"/>
         <element name="Metadata" type="oaf:MetadataType" minOccurs="0"/>
       </sequence>
-      <attribute name="configVersion" use="required">
-        <simpleType>
-          <restriction base="string">
-            <enumeration value="3.4.0"/>
-          </restriction>
-        </simpleType>
-      </attribute>
+      <attribute name="configVersion" use="optional"/>
     </complexType>
   </element>
 


### PR DESCRIPTION
Updated the configVersion of the example configurations in the documentation from 3.4.0 to 3.5.0.

The used schemaLocation needs a review, since as of now https://schemas.deegree.org/3.5/ does not list the schemas for OGC API.