### PR TITLE
Fix of encoding for GeoJson responses

### DIFF
--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/io/response/FeaturesResponseCreator.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/io/response/FeaturesResponseCreator.java
@@ -23,8 +23,10 @@ package org.deegree.services.oaf.io.response;
 
 import org.deegree.services.oaf.link.Link;
 
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Map;
 
@@ -33,7 +35,7 @@ import static org.deegree.services.oaf.OgcApiFeaturesConstants.HEADER_LINK;
 import static org.deegree.services.oaf.OgcApiFeaturesConstants.HEADER_NUMBER_MATCHED;
 import static org.deegree.services.oaf.OgcApiFeaturesConstants.HEADER_NUMBER_RETURNED;
 import static org.deegree.services.oaf.OgcApiFeaturesConstants.HEADER_TIMESTAMP;
-import static org.deegree.services.oaf.OgcApiFeaturesMediaType.APPLICATION_GEOJSON;
+import static org.deegree.services.oaf.OgcApiFeaturesMediaType.APPLICATION_GEOJSON_TYPE;
 import static org.deegree.services.oaf.OgcApiFeaturesMediaType.APPLICATION_GML;
 import static org.deegree.services.oaf.OgcApiFeaturesMediaType.APPLICATION_GML_32;
 import static org.deegree.services.oaf.OgcApiFeaturesMediaType.APPLICATION_GML_SF0;
@@ -54,8 +56,11 @@ public class FeaturesResponseCreator {
      * @return never <code>null</code>
      */
     public Response createJsonResponseWithHeaders( AbstractFeatureResponse featureResponse ) {
-        Response.ResponseBuilder response = Response.ok( featureResponse, APPLICATION_GEOJSON );
-        response.header( HEADER_CONTENT_CRS, asContentCrsHeader( featureResponse ) );
+        Response.ResponseBuilder response = Response.ok( featureResponse );
+        response.header( HEADER_CONTENT_CRS, asContentCrsHeader( featureResponse ) )
+                .header( HttpHeaders.CONTENT_TYPE, APPLICATION_GEOJSON_TYPE.withCharset( StandardCharsets.UTF_8.name() ) )
+                .encoding( StandardCharsets.UTF_8.name() );
+
         return response.build();
     }
 

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/io/response/geojson/AbstractFeatureResponseGeoJsonWriter.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/io/response/geojson/AbstractFeatureResponseGeoJsonWriter.java
@@ -23,9 +23,12 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.List;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
+ * This class provides capabilities to write GeoJson output format to writer.
+ *
  * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
  */
 public abstract class AbstractFeatureResponseGeoJsonWriter<T extends AbstractFeatureResponse>
@@ -45,8 +48,8 @@ public abstract class AbstractFeatureResponseGeoJsonWriter<T extends AbstractFea
                          MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream out )
                     throws WebApplicationException {
         try (
-                        Writer writer = new PrintWriter( out );
-                        GeoJsonWriter geoJsonStreamWriter = new GeoJsonWriter( writer, asCrs( feature ) ) ) {
+                Writer writer = new PrintWriter( out, false , UTF_8 );
+                GeoJsonWriter geoJsonStreamWriter = new GeoJsonWriter( writer, asCrs( feature ) ) ) {
             writeContent( feature, geoJsonStreamWriter );
         } catch ( Exception e ) {
             LOG.error( "Writing response failed", e );

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/io/response/FeaturesResponseCreatorTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/io/response/FeaturesResponseCreatorTest.java
@@ -1,0 +1,40 @@
+package org.deegree.services.oaf.io.response;
+
+import org.deegree.feature.stream.EmptyFeatureInputStream;
+import org.deegree.feature.stream.FeatureInputStream;
+import org.deegree.services.oaf.OgcApiFeaturesConstants;
+import org.deegree.services.oaf.link.Link;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.deegree.services.oaf.OgcApiFeaturesMediaType.APPLICATION_GEOJSON_TYPE;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class FeaturesResponseCreatorTest {
+
+    @Test
+    public void createJsonResponseWithHeaders() {
+        FeaturesResponseCreator responseCreator = new FeaturesResponseCreator();
+        FeatureResponse featureResponse = createFeatureResponse();
+        Response response = responseCreator.createJsonResponseWithHeaders( featureResponse );
+
+        assertThat( response.getStatus(), equalTo( 200 ) );
+        assertThat( response.getMediaType(), equalTo( APPLICATION_GEOJSON_TYPE.withCharset( UTF_8.name() ) ) );
+    }
+
+   private FeatureResponse createFeatureResponse() {
+        List<Link> links = Collections.singletonList(
+                new Link( "http://self", "self", "application/json", "title" ) );
+        FeatureInputStream featureStream = new EmptyFeatureInputStream();
+        Map<String, String> featureTypeNsPrefixes = Collections.emptyMap();
+        return new FeaturesResponseBuilder( featureStream ).withFeatureTypeNsPrefixes(
+                featureTypeNsPrefixes ).withLinks( links ).withResponseCrsName(
+                OgcApiFeaturesConstants.DEFAULT_CRS ).buildFeatureResponse();
+    }
+}


### PR DESCRIPTION
#55 fix for encoding of GeoJson responses, setting header for content to utf-8 same as for WFS GeoJson responses