### PR TITLE
Exclude dependencies that are included in Java 11+

### DIFF
--- a/deegree-ogcapi-config/pom.xml
+++ b/deegree-ogcapi-config/pom.xml
@@ -60,10 +60,6 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
-    <dependency>
-      <groupId>xml-apis</groupId>
-      <artifactId>xml-apis</artifactId>
-    </dependency>
   </dependencies>
 
 </project>

--- a/deegree-ogcapi-features/pom.xml
+++ b/deegree-ogcapi-features/pom.xml
@@ -103,14 +103,6 @@
       <artifactId>httpcore</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-stax-api_1.0_spec</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>xml-apis</groupId>
-      <artifactId>xml-apis</artifactId>
-    </dependency>
-    <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -567,6 +567,12 @@
         <groupId>org.deegree</groupId>
         <artifactId>deegree-core-commons</artifactId>
         <version>${deegree-version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-stax-api_1.0_spec</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.deegree</groupId>
@@ -749,11 +755,12 @@
         <groupId>xerces</groupId>
         <artifactId>xercesImpl</artifactId>
         <version>2.12.2</version>
-      </dependency>
-      <dependency>
-        <groupId>xml-apis</groupId>
-        <artifactId>xml-apis</artifactId>
-        <version>1.4.01</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>xml-apis</artifactId>
+            <groupId>xml-apis</groupId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <!-- logging -->
       <dependency>


### PR DESCRIPTION
...because when generating Eclipse projects with Maven, in Eclipse there are compile errors like these if the dependencies are included:

```
The package javax.xml.stream is accessible from more than one module: <unnamed>, java.xml
```

Additional context:

- The Maven build itself does not seem to be impacted by the dependencies, just the Eclipse compiler
- Java version used: 17
- Generated Eclipse projects with command similar to `mvn eclipse:clean eclipse:configure-workspace eclipse:eclipse -Declipse.workspace=<workspace-folder> -Dwtpversion=2.0`