### PR TITLE
Add "openapi" alias for api endpoint

### DIFF
--- a/deegree-ogcapi-documentation/src/main/asciidoc/usage.adoc
+++ b/deegree-ogcapi-documentation/src/main/asciidoc/usage.adoc
@@ -49,7 +49,7 @@ NOTE: The context for the listed resource is _datasets/{datasetId}_. The OGC API
 [[openapi]]
 === OpenAPI document
 
-The OpenAPI page is available under the context _/api_. The use of _/api_ on the server is optional and the API definition may be hosted on completely separate server.
+The OpenAPI page is available under the context _/api_ or _/openapi_. The use of _/api_ on the server is optional and the API definition may be hosted on completely separate server.
 If you have deployed the deegree OAF webapp under the context of _deegree-services-oaf_ and you have a dataset configured with the name
 _streets_ the resulting request path would be _/deegree-services-oaf/datasets/streets/api_.
 

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/filter/OpenApiAliasFilter.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/filter/OpenApiAliasFilter.java
@@ -1,0 +1,57 @@
+/*-
+ * #%L
+ * deegree-ogcapi-features - OGC API Features (OAF) implementation - Querying and modifying of geospatial data objects
+ * %%
+ * Copyright (C) 2019 - 2020 lat/lon GmbH, info@lat-lon.de, www.lat-lon.de
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package org.deegree.services.oaf.filter;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.PathSegment;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Filter that provides OpenApi endpoints under the alias "openapi" in addition to the original "api".
+ */
+@Provider
+@PreMatching
+public class OpenApiAliasFilter implements ContainerRequestFilter {
+
+	@Override
+	public void filter(ContainerRequestContext requestContext) throws IOException {
+		UriInfo orgUri = requestContext.getUriInfo();
+		List<PathSegment> segments = orgUri.getPathSegments();
+		
+		// if the relative path is /datasets/{dataset}/openapi* replace "openapi" with "api"
+		if (segments.size() == 3 && segments.get(2).getPath().startsWith("openapi") && "datasets".equals(segments.get(0).getPath())) {
+			StringBuilder newPath = new StringBuilder(orgUri.getBaseUri().getPath());
+			newPath.append("datasets/");
+			newPath.append(segments.get(1).getPath());
+			newPath.append("/");
+			newPath.append(segments.get(2).getPath().replace("openapi", "api"));
+			requestContext.setRequestUri(orgUri.getBaseUri(), orgUri.getRequestUriBuilder().replacePath(newPath.toString()).build());
+		}
+	}
+
+}

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/resource/OpenApiTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/resource/OpenApiTest.java
@@ -23,16 +23,15 @@ package org.deegree.services.oaf.resource;
 
 import org.apache.commons.io.IOUtils;
 import org.deegree.services.oaf.OgcApiFeaturesMediaType;
+import org.deegree.services.oaf.filter.OpenApiAliasFilter;
 import org.deegree.services.oaf.openapi.OpenApiCreator;
 import org.deegree.services.oaf.workspace.DeegreeWorkspaceInitializer;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
@@ -42,16 +41,14 @@ import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.isJson;
 import static org.deegree.services.oaf.TestData.mockWorkspaceInitializer;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -82,6 +79,7 @@ public class OpenApiTest extends JerseyTest {
         when(servletConfig.getServletContext()).thenReturn(servletContext);
         ResourceConfig resourceConfig = new ResourceConfig();
         resourceConfig.packages("org.deegree.services.oaf.resource");
+        resourceConfig.register(OpenApiAliasFilter.class);
         resourceConfig.register(new AbstractBinder() {
             @Override
             protected void configure() {
@@ -97,6 +95,13 @@ public class OpenApiTest extends JerseyTest {
     @Test
     public void test_OpenApiDeclarationShouldBeAvailable() {
         int status = target("/datasets/oaf/api").request(
+                OgcApiFeaturesMediaType.APPLICATION_OPENAPI).get().getStatus();
+        assertThat(status, is(200));
+    }
+    
+    @Test
+    public void test_OpenApiDeclarationAliasShouldBeAvailable() {
+        int status = target("/datasets/oaf/openapi").request(
                 OgcApiFeaturesMediaType.APPLICATION_OPENAPI).get().getStatus();
         assertThat(status, is(200));
     }


### PR DESCRIPTION
Adds an alias "openapi" for the existing "api" endpoint that serves the OpenAPI definition.

See #76 