### PR TITLE
Add OpenAPI description also in YAML format

### DIFF
--- a/deegree-ogcapi-documentation/src/main/asciidoc/configuration.adoc
+++ b/deegree-ogcapi-documentation/src/main/asciidoc/configuration.adoc
@@ -457,3 +457,8 @@ The REST-API is enabled by default. To protect this interface from unauthorized 
 
 A detailed documentation of the REST-API interface and how access is configured is described in section "deegree REST interface"
 of the https://download.deegree.org/documentation/3.4.17/html/#anchor-configuration-restapi[deegree webservices handbook].
+
+=== Allow access to OpenAPI document from all origins
+
+In case you want to avoid any issues when using the OpenAPI document from other locations due to CORS, you can enable allowing all origins specifically for accessing the OpenAPI document.
+To enable this set the system property ```deegree.oaf.openapi.cors.allow_all``` to _true_.

--- a/deegree-ogcapi-documentation/src/main/asciidoc/usage.adoc
+++ b/deegree-ogcapi-documentation/src/main/asciidoc/usage.adoc
@@ -34,7 +34,7 @@ The following table show the resources available per dataset:
 |===
 |Resource |Path |HTTP method |Supported Encodings |Description
 |Landing page |`/` |GET |`text/html`, `application/json` |Landing page is the top-level resource, which serves as an entry point per dataset
-|OpenAPI |`/api` |GET | `text/html`, `application/json` |API specification document provides metadata about the API itself
+|OpenAPI |`/api` |GET | `text/html`, `application/json`, `application/yaml` |API specification document provides metadata about the API itself
 |Conformance declaration |`/conformance` |GET |`text/html`, `application/json` |Declaration of conformance classes presents information about the functionality that is implemented by the server
 |Feature collections |`/collections` |GET | `text/html`, `application/json`, `application/xml` |Feature collections overview
 |Feature collection |`+/collections/{collectionId}+` |GET | `text/html`, `application/json`, `application/xml` |Feature collection identified by {collectionId}

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/OgcApiFeaturesMediaType.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/OgcApiFeaturesMediaType.java
@@ -35,6 +35,9 @@ public final class OgcApiFeaturesMediaType {
     public static final String APPLICATION_OPENAPI = "application/vnd.oai.openapi+json;version=3.0";
     public static final MediaType APPLICATION_OPENAPI_TYPE = new MediaType("application", "vnd.oai.openapi+json;version=3.0");
     
+    public static final String APPLICATION_OPENAPI_YAML = "application/vnd.oai.openapi+yaml;version=3.0";
+    public static final MediaType APPLICATION_OPENAPI_YAML_TYPE = new MediaType("application", "vnd.oai.openapi+yaml;version=3.0");
+    
     // Note: There is no registered media type yet, but this is the latest proposal
     // See https://github.com/ietf-wg-httpapi/mediatypes/blob/main/draft-ietf-httpapi-yaml-mediatypes.md
     public static final String APPLICATION_YAML = "application/yaml";

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/OpenApi.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/OpenApi.java
@@ -27,6 +27,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.models.OpenAPI;
 import org.apache.http.HttpStatus;
+import org.deegree.commons.utils.TunableParameter;
 import org.deegree.services.oaf.openapi.OpenApiCreator;
 import org.slf4j.Logger;
 
@@ -39,6 +40,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.io.File;
 import java.io.FileInputStream;
@@ -56,6 +58,13 @@ import static org.slf4j.LoggerFactory.getLogger;
  */
 @Path("/datasets/{datasetId}/api")
 public class OpenApi {
+	
+	/**
+	 * Name for parameter that allows enabling allowing all origins for CORS. 
+	 */
+	public static final String PARAMETER_CORS_ALLOWALL = "deegree.oaf.openapi.cors.allow_all";
+	
+	private final boolean corsAllowAll = TunableParameter.get(PARAMETER_CORS_ALLOWALL, false);
 
     private static final Logger LOG = getLogger( OpenApi.class );
 
@@ -105,7 +114,12 @@ public class OpenApi {
         	rendered = Yaml.mapper().writeValueAsString( openApi );
         }
         
-        return Response.status( Response.Status.OK ).entity( rendered ).build();
+        ResponseBuilder resp = Response.status( Response.Status.OK )
+        		.entity( rendered );
+        if (corsAllowAll) {
+        	resp.header( "Access-Control-Allow-Origin", "*" );
+        }
+        return resp.build();
 	}
 
 	@GET

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/OpenApi.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/OpenApi.java
@@ -22,6 +22,7 @@
 package org.deegree.services.oaf.resource;
 
 import io.swagger.v3.core.util.Json;
+import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -46,6 +47,8 @@ import java.io.FileNotFoundException;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_HTML;
 import static org.deegree.services.oaf.OgcApiFeaturesMediaType.APPLICATION_OPENAPI;
+import static org.deegree.services.oaf.OgcApiFeaturesMediaType.APPLICATION_OPENAPI_YAML;
+import static org.deegree.services.oaf.OgcApiFeaturesMediaType.APPLICATION_YAML;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -72,14 +75,40 @@ public class OpenApi {
                     @PathParam("datasetId")
                                     String datasetId )
                     throws Exception {
-        OpenAPI openApi = this.openApiCreator.createOpenApi( headers, datasetId );
+        return respondWithOpenApi( headers, datasetId, true );
+    }
+    
+    @GET
+    @Produces({ APPLICATION_OPENAPI_YAML, APPLICATION_YAML })
+    @Operation(operationId = "openApi", summary = "api documentation", description = "api documentation")
+    @Tag(name = "Capabilities")
+    public Response getOpenApiOpenApiYaml(
+                    @Context HttpHeaders headers,
+                    @Context UriInfo uriInfo,
+                    @PathParam("datasetId")
+                                    String datasetId )
+                    throws Exception {
+        return respondWithOpenApi( headers, datasetId, false );
+    }
+
+    private Response respondWithOpenApi(HttpHeaders headers, String datasetId, boolean json) throws Exception {
+    	OpenAPI openApi = this.openApiCreator.createOpenApi( headers, datasetId );
 
         if ( openApi == null )
             return Response.status( 404 ).build();
-        return Response.status( Response.Status.OK ).entity( Json.mapper().writeValueAsString( openApi ) ).build();
-    }
+        
+        String rendered;
+        if (json) {
+        	rendered = Json.mapper().writeValueAsString( openApi );
+        }
+        else {
+        	rendered = Yaml.mapper().writeValueAsString( openApi );
+        }
+        
+        return Response.status( Response.Status.OK ).entity( rendered ).build();
+	}
 
-    @GET
+	@GET
     @Produces({ TEXT_HTML })
     @Operation(hidden = true)
     public Response getOpenApiHtml() {

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/resource/OpenApiCorsTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/resource/OpenApiCorsTest.java
@@ -1,0 +1,59 @@
+/*-
+ * #%L
+ * deegree-ogcapi-features - OGC API Features (OAF) implementation - Querying and modifying of geospatial data objects
+ * %%
+ * Copyright (C) 2019 - 2020 lat/lon GmbH, info@lat-lon.de, www.lat-lon.de
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package org.deegree.services.oaf.resource;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import javax.ws.rs.core.Response;
+
+import org.deegree.services.oaf.OgcApiFeaturesMediaType;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test OpenApi resource with CORS header enabled.
+ */
+public class OpenApiCorsTest extends OpenApiTest {
+	
+	@BeforeClass
+	public static void setProperties() {
+		System.setProperty( OpenApi.PARAMETER_CORS_ALLOWALL, "true" );
+	}
+	
+	@AfterClass
+	public static void resetProperties() {
+		System.setProperty( OpenApi.PARAMETER_CORS_ALLOWALL, "" );
+	}
+
+    /**
+     * Test that when enabled a CORS header is returned.
+     */
+    @Test
+    @Override
+    public void test_OpenApiCorsHeader() {
+        Response response = target("/datasets/oaf/api").request(OgcApiFeaturesMediaType.APPLICATION_OPENAPI).get();
+        assertThat( response.getHeaderString( "Access-Control-Allow-Origin" ), is("*"));
+    }
+
+}

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/resource/OpenApiTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/resource/OpenApiTest.java
@@ -21,7 +21,7 @@
  */
 package org.deegree.services.oaf.resource;
 
-import org.apache.commons.io.IOUtils;
+import org.deegree.commons.utils.TunableParameter;
 import org.deegree.services.oaf.OgcApiFeaturesMediaType;
 import org.deegree.services.oaf.filter.OpenApiAliasFilter;
 import org.deegree.services.oaf.openapi.OpenApiCreator;
@@ -49,6 +49,7 @@ import static com.jayway.jsonpath.matchers.JsonPathMatchers.isJson;
 import static org.deegree.services.oaf.TestData.mockWorkspaceInitializer;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -72,6 +73,8 @@ public class OpenApiTest extends JerseyTest {
 
     @Override
     protected Application configure() {
+    	TunableParameter.resetCache();
+    	
         enable(TestProperties.LOG_TRAFFIC);
         ServletContext servletContext = mock(ServletContext.class);
         when(servletContext.getContextPath()).thenReturn("");
@@ -93,7 +96,7 @@ public class OpenApiTest extends JerseyTest {
         return resourceConfig;
     }
 
-    @Test
+	@Test
     public void test_OpenApiDeclarationShouldBeAvailable() {
         int status = target("/datasets/oaf/api").request(
                 OgcApiFeaturesMediaType.APPLICATION_OPENAPI).get().getStatus();
@@ -128,6 +131,15 @@ public class OpenApiTest extends JerseyTest {
         Response response = target( "/datasets/oaf/api/swagger-ui-bundle.js" ).request().get();
         assertThat( response.getStatus(), is( 200 ) );
         assertThat( response.getMediaType().toString(), is( "text/javascript" ) );
+    }
+    
+    /**
+     * Test that by default there is no CORS header returned.
+     */
+    @Test
+    public void test_OpenApiCorsHeader() {
+        Response response = target("/datasets/oaf/api").request(OgcApiFeaturesMediaType.APPLICATION_OPENAPI).get();
+        assertThat( response.getHeaderString( "Access-Control-Allow-Origin" ), is(nullValue()));
     }
 
     @Test

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/resource/OpenApiTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/resource/OpenApiTest.java
@@ -38,6 +38,7 @@ import org.junit.rules.TemporaryFolder;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
 import javax.ws.rs.core.Application;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -109,6 +110,12 @@ public class OpenApiTest extends JerseyTest {
     @Test public void test_OpenApiHtmlShouldBeAvailable() {
         int status = target( "/datasets/oaf/api" ).request( MediaType.TEXT_HTML ).get().getStatus();
         assertThat( status, is( 200 ) );
+    }
+    
+    @Test public void test_OpenApiYamlShouldBeAvailable() {
+        Response response = target( "/datasets/oaf/api" ).request( OgcApiFeaturesMediaType.APPLICATION_YAML_TYPE ).get();
+        assertThat( response.getStatus(), is( 200 ) );
+        assertThat( response.getHeaderString( HttpHeaders.CONTENT_TYPE ), is( OgcApiFeaturesMediaType.APPLICATION_YAML ) );
     }
 
     @Test public void test_OpenApiCssShouldReturnCorrectMimeType() {


### PR DESCRIPTION
Support serving the OpenAPI description as YAML in addition to the
already supported JSON format.
Also add a configuration option to allow CORS access for all origins. By default this is disabled.

See #76 

**Please note:** Includes changes from PR #81 due to dependency on YAML media type defined there, thus #81 should be merged first.