### PR TITLE
Fixes the use of storage CRS code from list of supported CRS

### DIFF
--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/OafResource.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/OafResource.java
@@ -276,7 +276,7 @@ public class OafResource implements Resource {
         List<MetadataUrl> metadataUrls = datasetMetadata != null && !datasetMetadata.getMetadataUrls().isEmpty() ?
                                          datasetMetadata.getMetadataUrls() :
                                          Collections.emptyList();
-        String storageCrs = featureStore.getStorageCrs() != null ? featureStore.getStorageCrs().getName() : null;
+        String[] storageCrsCodes = featureStore.getStorageCrs() != null ? featureStore.getStorageCrs().getOrignalCodeStrings() : null;
         return new FeatureTypeMetadata( name )
                         .dateTimeProperty( dateTimeProperty )
                         .extent( extent )
@@ -285,7 +285,7 @@ public class OafResource implements Resource {
                         .metadataUrls( metadataUrls )
                         .filterProperties( filterProperties )
                         .featureType( featureType )
-                        .storageCrs( storageCrs );
+                        .storageCrsCodes( storageCrsCodes != null ? Arrays.asList( storageCrsCodes ) : null );
     }
 
     private List<FilterProperty> parseFilterProperties( FeatureType featureType ) {

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/configuration/FeatureTypeMetadata.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/configuration/FeatureTypeMetadata.java
@@ -49,7 +49,7 @@ public class FeatureTypeMetadata {
 
     private FeatureType featureType;
 
-    private String storageCrs;
+    private List<String> storageCrsCodes;
 
     public FeatureTypeMetadata( QName featureTypeName ) {
         this.name = featureTypeName;
@@ -91,8 +91,8 @@ public class FeatureTypeMetadata {
         return this;
     }
 
-    public FeatureTypeMetadata storageCrs( String storageCrs ) {
-        this.storageCrs = storageCrs;
+    public FeatureTypeMetadata storageCrsCodes( List<String> storageCrsCodes ) {
+        this.storageCrsCodes = storageCrsCodes;
         return this;
     }
 
@@ -128,7 +128,7 @@ public class FeatureTypeMetadata {
         return featureType;
     }
 
-    public String getStorageCrs() {
-        return storageCrs;
+    public List<String> getStorageCrsCodes() {
+        return storageCrsCodes;
     }
 }

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/workspace/DeegreeDataAccessTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/workspace/DeegreeDataAccessTest.java
@@ -1,0 +1,72 @@
+/*-
+ * #%L
+ * deegree-ogcapi-features - OGC API Features (OAF) implementation - Querying and modifying of geospatial data objects
+ * %%
+ * Copyright (C) 2019 - 2020 lat/lon GmbH, info@lat-lon.de, www.lat-lon.de
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package org.deegree.services.oaf.workspace;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.deegree.cs.coordinatesystems.ICRS;
+import org.deegree.cs.exceptions.UnknownCRSException;
+import org.deegree.cs.persistence.CRSManager;
+import org.junit.Test;
+
+public class DeegreeDataAccessTest {
+	
+	@Test
+	public void test_selectCrsCode_ETRS89() throws UnknownCRSException {
+		String lookupCode = "http://www.opengis.net/def/crs/EPSG/0/4258";
+		String code = selectCode( lookupCode, Arrays.asList( lookupCode ) );
+		assertThat( code, is( lookupCode ));
+	}
+	
+	@Test
+	public void test_selectCrsCode_WGS84() throws UnknownCRSException {
+		String lookupCode = "http://www.opengis.net/def/crs/EPSG/0/4326";
+		String code = selectCode( lookupCode, Arrays.asList( lookupCode ) );
+		assertThat( code, is( lookupCode ) );
+	}
+	
+	@Test
+	public void test_selectCrsCode_ETRS89_AlternateCode() throws UnknownCRSException {
+		String lookupCode = "urn:ogc:def:crs:EPSG::4258";
+		String allowedCode = "http://www.opengis.net/def/crs/EPSG/0/4258";
+		String code = selectCode( lookupCode, Arrays.asList( allowedCode ) );
+		assertThat( code, is( allowedCode ) );
+	}
+	
+	@Test
+	public void test_selectCrsCode_NoMatch() throws UnknownCRSException {
+		String lookupCode = "http://www.opengis.net/def/crs/EPSG/0/4326";
+		ICRS crs = CRSManager.lookup( lookupCode );
+		String code = selectCode( lookupCode, Arrays.asList( "EPSG:12345" ) );
+		assertThat( code, is( crs.getCode().getOriginal() ));
+	}
+	
+	private String selectCode( String crsCode, List<String> supportedCodes ) throws UnknownCRSException {
+		ICRS crs = CRSManager.lookup( crsCode );
+		return DeegreeDataAccess.selectCrsCode( Arrays.asList( crs.getOrignalCodeStrings() ), supportedCodes );
+	}
+
+}


### PR DESCRIPTION
...instead of the CRS name.
If no match can be found for the storage CRS codes in the list of supported CRS, the first of the storage CRS codes is used.

This is done to if possible fulfill the requirement in the specification of OGC API Features Part 2, that the storage CRS shall be one of the identifiers of the supported CRS.

Since we can't determine for the storage CRS which code was initially used to specify it, we use the list of supported query CRS for deegree OAF as a way to determine the desired code, if possible. So with these changes to fulfill the requirement of the OGC spec you need to specify the desired code for the storage CRS as part of the supported query CRS.

Solves #89 