### PR TITLE
Dockerfile health check fix and small improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,12 +31,12 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
 # copy webapp
 COPY --from=builder /target /webapp
 
-# folder for workspace root
+# default folder for workspace root
 ENV DEEGREE_WORKSPACE_ROOT=/workspaces
-RUN mkdir $DEEGREE_WORKSPACE_ROOT && \
-  (rm -r /usr/local/tomcat/webapps/ROOT || true)
 
-VOLUME $DEEGREE_WORKSPACE_ROOT
+# create default workspace root and delete any existing ROOT webapp
+RUN mkdir /workspaces && \
+  (rm -r /usr/local/tomcat/webapps/ROOT || true)
 
 # copy health check script and make it executable
 COPY ./docker/ /docker-scripts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,17 +28,6 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
   org.opencontainers.image.source=$VCS_URL \
   org.opencontainers.image.revision=$VCS_REF
 
-# tomcat port
-EXPOSE 8080
-
-# get dataset list as health check
-HEALTHCHECK \
-    --interval=60s \
-    --timeout=15s \
-    --start-period=2m \
-    --retries=3 \
-    CMD curl --fail http://localhost:8080/datasets || exit 1
-
 # copy webapp
 COPY --from=builder /target /webapp
 
@@ -49,11 +38,26 @@ RUN mkdir $DEEGREE_WORKSPACE_ROOT && \
 
 VOLUME $DEEGREE_WORKSPACE_ROOT
 
+# copy health check script and make it executable
+COPY ./docker/ /docker-scripts/
+RUN chmod a+x /docker-scripts/*.sh
+
+# health check (get dataset list)
+HEALTHCHECK \
+  --interval=60s \
+  --timeout=15s \
+  --start-period=2m \
+  --retries=3 \
+  CMD /docker-scripts/liveness-check.sh
+
 # context path to deploy webapp at; defaults to ROOT, can be overridden for container
 ENV DEEGREE_CONTEXT_PATH=ROOT
 
 # API key to use; if empty will not change API key
 ENV DEEGREE_API_KEY=
+
+# tomcat port
+EXPOSE 8080
 
 # Good article on possibilities to control context path:
 # https://octopus.com/blog/defining-tomcat-context-paths

--- a/README.md
+++ b/README.md
@@ -51,11 +51,14 @@ By default using the Docker image deegree ogcapi is served at the root context (
 
 You can use the environment variable `DEEGREE_CONTEXT_PATH` to use a different context path.
 
-For example, if you run the container using this command, the context `/deegree-services-oaf` context path is used and the Datasets overview page is available at <http://localhost:8080/deegree-services-oaf/datasets>:
+For example, if you run the container using this command, the context path `/deegree-services-oaf` is used and the Datasets overview page is available at <http://localhost:8080/deegree-services-oaf/datasets>:
 
 ```
 docker run --name ogcapi -d -p 8080:8080 -e DEEGREE_CONTEXT_PATH=deegree-services-oaf deegree/deegree-ogcapi:latest
 ```
+
+To use a context path with multiple path segments, you need to use `#` as a separator.
+So if you for instance configure `DEEGREE_CONTEXT_PATH` as `deegree#is#awesome` then the context path is `/deegree/is/awesome`.
 
 #### Configure an API key
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ By default the application runs in the root context, so you can then access the 
 
 The container expects the configuration for the default workspace, the API key and the workspace folders at `/workspaces`.
 You can mount a folder to this location or use a volume.
+If you want to use a different folder within the container you need to override the environment variable `DEEGREE_WORKSPACE_ROOT`.
 
 See the [Docker CLI documentation](https://docs.docker.com/engine/reference/commandline/cli/) for more information how to connect a container to a network, mount a volume into the container, or set environment variables.
 

--- a/docker/liveness-check.sh
+++ b/docker/liveness-check.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+if [ "$DEEGREE_CONTEXT_PATH" = "ROOT" ]; then
+  CONTEXT=""
+else
+  CONTEXT=$(echo "$DEEGREE_CONTEXT_PATH" | tr "#" "/")
+  CONTEXT="/$CONTEXT"
+fi
+
+echo "Determined context $CONTEXT"
+
+URL="http://localhost:8080${CONTEXT}/datasets"
+echo "Checking URL ${URL}..."
+
+curl --fail "$URL" || exit 1


### PR DESCRIPTION
Improvements related to Dockerfile:

- fix health check (now also works if a different context path is configured)
- add example on context path with multiple segments to README
- remove VOLUME instruction from Dockerfile
- make more clear how the workspace root is configured and that the `/workspaces` folder is just a default for the image