### PR TITLE
Fix link relation type to OpenAPI specification

### DIFF
--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/link/LinkBuilder.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/link/LinkBuilder.java
@@ -242,7 +242,7 @@ public class LinkBuilder {
 
     private void addServiceDesc( List<Link> links, String apiHref ) {
         links.add( new Link( apiHref, SERVICE_DESC.getRel(), APPLICATION_OPENAPI, "API definition" ) );
-        links.add( new Link( apiHref, SERVICE_DESC.getRel(), TEXT_HTML, "API definition as HTML" ) );
+        links.add( new Link( apiHref, SERVICE_DOC.getRel(), TEXT_HTML, "API definition as HTML" ) );
     }
 
     private void addData( List<Link> links, String collectionsHref ) {

--- a/deegree-ogcapi-features/src/main/resources/landingpage.html
+++ b/deegree-ogcapi-features/src/main/resources/landingpage.html
@@ -182,7 +182,7 @@ var App = new Vue({
 
       this.title = json.title;
       this.description = json.description;
-      this.apilink = firstByRel(json, 'service-desc');
+      this.apilink = firstByRel(json, 'service-doc');
       this.collectionlink = firstByRel(json, 'data');
       this.conformanceLink = firstByRel(json, 'conformance');
       this.metadataLink = firstByRel(json, 'describedBy', true);

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/resource/LandingPageTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/resource/LandingPageTest.java
@@ -55,6 +55,7 @@ import static org.deegree.services.oaf.link.LinkRelation.CONFORMANCE;
 import static org.deegree.services.oaf.link.LinkRelation.DATA;
 import static org.deegree.services.oaf.link.LinkRelation.SELF;
 import static org.deegree.services.oaf.link.LinkRelation.SERVICE_DESC;
+import static org.deegree.services.oaf.link.LinkRelation.SERVICE_DOC;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.xmlunit.matchers.HasXPathMatcher.hasXPath;
@@ -185,7 +186,7 @@ public class LandingPageTest extends JerseyTest {
         assertThat( xml, hasXPath( linkWith( ALTERNATE, APPLICATION_XML ) ).withNamespaceContext( nsContext() ) );
         assertThat( xml,
                     hasXPath( linkWith( SERVICE_DESC, APPLICATION_OPENAPI ) ).withNamespaceContext( nsContext() ) );
-        assertThat( xml, hasXPath( linkWith( SERVICE_DESC, TEXT_HTML ) ).withNamespaceContext( nsContext() ) );
+        assertThat( xml, hasXPath( linkWith( SERVICE_DOC, TEXT_HTML ) ).withNamespaceContext( nsContext() ) );
         assertThat( xml, hasXPath( linkWith( CONFORMANCE, APPLICATION_JSON ) ).withNamespaceContext( nsContext() ) );
         assertThat( xml, hasXPath( linkWith( CONFORMANCE, TEXT_HTML ) ).withNamespaceContext( nsContext() ) );
         assertThat( xml, hasXPath( linkWith( CONFORMANCE, APPLICATION_XML ) ).withNamespaceContext( nsContext() ) );


### PR DESCRIPTION
This pull request fixes the relation type of the link towards the OpenAPI specification to "service-doc" for text/html media type.