### PR TITLE
Upgrade maven plugins to latest bugfix version

### DIFF
--- a/deegree-ogcapi-webapp/pom.xml
+++ b/deegree-ogcapi-webapp/pom.xml
@@ -41,7 +41,7 @@
         <plugin>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-maven-plugin</artifactId>
-          <version>11.0.15</version>
+          <version>11.0.18</version>
           <configuration>
             <webApp>
               <contextPath>/deegree-ogcapi</contextPath>

--- a/pom.xml
+++ b/pom.xml
@@ -133,12 +133,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.6.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.2.2</version>
           <configuration>
             <!-- Travis build workaround -->
             <argLine>-Xms1024m -Xmx2048m</argLine>
@@ -147,12 +147,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.2.2</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.16.0</version>
+          <version>2.16.1</version>
         </plugin>
         <!-- reporting and site -->
         <plugin>
@@ -205,7 +205,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.2</version>
           <configuration>
             <doclint>none</doclint>
           </configuration>
@@ -229,12 +229,12 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>properties-maven-plugin</artifactId>
-          <version>1.2.0</version>
+          <version>1.2.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.1</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -449,7 +449,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
       </plugin>
     </plugins>
   </build>
@@ -459,7 +459,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.2</version>
         <configuration>
           <doclint>none</doclint>
           <detectLinks>false</detectLinks>
@@ -933,7 +933,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-pmd-plugin</artifactId>
-            <version>3.21.0</version>
+            <version>3.21.2</version>
             <configuration>
               <linkXref>true</linkXref>
               <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
@@ -950,7 +950,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>3.3.0</version>
+            <version>3.3.1</version>
             <configuration>
               <configLocation>checkstyle.xml</configLocation>
             </configuration>
@@ -958,7 +958,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jxr-plugin</artifactId>
-            <version>3.3.0</version>
+            <version>3.3.1</version>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -972,7 +972,7 @@
           <plugin>
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
-            <version>8.3.1</version>
+            <version>8.4.3</version>
             <configuration>
               <cveValidForHours>24</cveValidForHours>
               <knownExploitedEnabled>false</knownExploitedEnabled>


### PR DESCRIPTION
This PR upgrades the maven plugins surefire, failsafe, javadoc, versions, enforcer, and jetty plugin to latest bugfix version