### PR TITLE
Upgrade deegree and jaxb to latest bugfix version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
             <dependency>
               <groupId>org.glassfish.jaxb</groupId>
               <artifactId>jaxb-runtime</artifactId>
-              <version>2.3.8</version>
+              <version>2.3.9</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -669,7 +669,7 @@
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-runtime</artifactId>
-        <version>2.3.8</version>
+        <version>2.3.9</version>
         <scope>runtime</scope>
       </dependency>
       <!-- swagger -->
@@ -901,7 +901,7 @@
     <swagger-version>2.1.13</swagger-version>
     <swagger-ui-version>3.52.5</swagger-ui-version>
     <jackson-version>2.14.3</jackson-version>
-    <deegree-version>3.5.0</deegree-version>
+    <deegree-version>3.5.3</deegree-version>
     <slf4j.version>1.7.36</slf4j.version>
     <log4j.version>2.17.2</log4j.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -901,7 +901,7 @@
     <swagger-version>2.1.13</swagger-version>
     <swagger-ui-version>3.52.5</swagger-ui-version>
     <jackson-version>2.14.3</jackson-version>
-    <deegree-version>3.5.3</deegree-version>
+    <deegree-version>3.5.4</deegree-version>
     <slf4j.version>1.7.36</slf4j.version>
     <log4j.version>2.17.2</log4j.version>
   </properties>


### PR DESCRIPTION
This PR upgrades JAXB to bugfix version 2.3.9 and deegree to 3.5.4.