### PR TITLE
Upgrade dependencies to latests version including deegree 3.5.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -907,7 +907,7 @@
     <swagger-version>2.2.20</swagger-version>
     <swagger-ui-version>3.52.5</swagger-ui-version>
     <jackson-version>2.16.1</jackson-version>
-    <deegree-version>3.5.6-SNAPSHOT</deegree-version>
+    <deegree-version>3.5.6</deegree-version>
     <slf4j.version>1.7.36</slf4j.version>
     <log4j.version>2.23.0</log4j.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
             <dependency>
               <groupId>org.deegree</groupId>
               <artifactId>deegree-jaxb-resolver</artifactId>
-              <version>1.0</version>
+              <version>1.1</version>
             </dependency>
             <dependency>
               <groupId>org.glassfish.jaxb</groupId>
@@ -120,7 +120,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>3.5.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -138,7 +138,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.2.2</version>
+          <version>3.2.5</version>
           <configuration>
             <!-- Travis build workaround -->
             <argLine>-Xms1024m -Xmx2048m</argLine>
@@ -147,19 +147,19 @@
             <dependency>
               <groupId>org.apache.maven.surefire</groupId>
               <artifactId>surefire-junit47</artifactId>
-              <version>3.2.2</version>
+              <version>3.2.5</version>
             </dependency>
           </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.2.2</version>
+          <version>3.2.5</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.16.1</version>
+          <version>2.16.2</version>
         </plugin>
         <!-- reporting and site -->
         <plugin>
@@ -170,7 +170,7 @@
             <dependency>
               <groupId>org.apache.maven.wagon</groupId>
               <artifactId>wagon-ssh</artifactId>
-              <version>3.4.3</version>
+              <version>3.5.3</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -192,7 +192,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>3.12.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -212,7 +212,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.6.2</version>
+          <version>3.6.3</version>
           <configuration>
             <doclint>none</doclint>
           </configuration>
@@ -225,7 +225,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-scm-plugin</artifactId>
-          <version>2.1.0</version>
+          <version>2.0.1</version>
         </plugin>
         <!-- git describe -->
         <plugin>
@@ -294,7 +294,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>[3.6,)</version>
+                  <version>[3.9,)</version>
                 </requireMavenVersion>
               </rules>
               <fail>true</fail>
@@ -329,7 +329,7 @@
           <dependency>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>extra-enforcer-rules</artifactId>
-            <version>1.6.2</version>
+            <version>1.7.0</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -456,7 +456,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
       </plugin>
     </plugins>
   </build>
@@ -466,7 +466,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.2</version>
         <configuration>
           <doclint>none</doclint>
           <detectLinks>false</detectLinks>
@@ -597,7 +596,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-collections4</artifactId>
-        <version>4.3</version>
+        <version>4.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.geronimo.specs</groupId>
@@ -708,7 +707,7 @@
       <dependency>
         <groupId>io.swagger.core.v3</groupId>
         <artifactId>swagger-integration</artifactId>
-        <version>2.1.13</version>
+        <version>${swagger-version}</version>
       </dependency>
       <!-- jackson -->
       <dependency>
@@ -801,7 +800,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>3.0.0</version>
+        <version>5.11.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -831,7 +830,7 @@
       <dependency>
         <groupId>com.jayway.jsonpath</groupId>
         <artifactId>json-path-assert</artifactId>
-        <version>2.4.0</version>
+        <version>2.9.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -855,18 +854,18 @@
       <dependency>
         <groupId>io.swagger.parser.v3</groupId>
         <artifactId>swagger-parser-v3</artifactId>
-        <version>2.0.33</version>
+        <version>2.1.21</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.7</version>
+        <version>2.15.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.7</version>
+        <version>3.14.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
@@ -888,13 +887,13 @@
       <dependency>
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
-        <version>2.9.9</version>
+        <version>2.12.7</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
-        <version>2.8.9</version>
+        <version>2.10.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -904,13 +903,13 @@
     <buildTimestamp>${maven.build.timestamp}</buildTimestamp>
     <java.version>11</java.version>
     <site.dir>${user.home}/Sites</site.dir>
-    <jersey-version>2.36</jersey-version>
-    <swagger-version>2.2.11</swagger-version>
+    <jersey-version>2.41</jersey-version>
+    <swagger-version>2.2.20</swagger-version>
     <swagger-ui-version>3.52.5</swagger-ui-version>
-    <jackson-version>2.14.3</jackson-version>
-    <deegree-version>3.5.4</deegree-version>
+    <jackson-version>2.16.1</jackson-version>
+    <deegree-version>3.5.6-SNAPSHOT</deegree-version>
     <slf4j.version>1.7.36</slf4j.version>
-    <log4j.version>2.17.2</log4j.version>
+    <log4j.version>2.23.0</log4j.version>
   </properties>
 
   <modules>
@@ -931,7 +930,7 @@
           <plugin>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-maven-plugin</artifactId>
-            <version>4.7.3.5</version>
+            <version>4.8.3.1</version>
             <configuration>
               <xmlOutput>true</xmlOutput>
               <findbugsXmlWithMessages>true</findbugsXmlWithMessages>
@@ -966,12 +965,12 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jxr-plugin</artifactId>
-            <version>3.3.1</version>
+            <version>3.3.2</version>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-project-info-reports-plugin</artifactId>
-            <version>3.4.5</version>
+            <version>3.5.0</version>
             <configuration>
               <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
               <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
@@ -980,7 +979,7 @@
           <plugin>
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
-            <version>8.4.3</version>
+            <version>9.0.9</version>
             <configuration>
               <cveValidForHours>24</cveValidForHours>
               <knownExploitedEnabled>false</knownExploitedEnabled>

--- a/pom.xml
+++ b/pom.xml
@@ -907,9 +907,9 @@
     <swagger-version>2.2.20</swagger-version>
     <swagger-ui-version>3.52.5</swagger-ui-version>
     <jackson-version>2.16.1</jackson-version>
-    <deegree-version>3.5.6</deegree-version>
-    <slf4j.version>1.7.36</slf4j.version>
-    <log4j.version>2.23.0</log4j.version>
+    <deegree-version>3.5.7</deegree-version>
+    <slf4j.version>2.0.12</slf4j.version>
+    <log4j.version>2.23.1</log4j.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
This PR upgrades dependencies and maven plugins to latest versions including upgrading to deegree bugfix version 3.5.7 which contains important upgrade of postgresql jdbc driver.

Important:
- This PR shall be merged after https://github.com/deegree/deegree3/pull/1663 into `3.5-main` and bugfix version released. This PR may require an update to the bugfix version containing the required changes.