### PR TITLE
Upgraded github actions to re-enable docker workflow

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -13,16 +13,16 @@ jobs:
   build-1_3:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push v1.3
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: ./docker/1.3
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build_maven.yml
+++ b/.github/workflows/build_maven.yml
@@ -20,4 +20,4 @@ jobs:
           distribution: temurin
           cache: 'maven'
       - name: Build with Maven
-        run: mvn -B -q verify --file pom.xml
+        run: mvn -B -q -ff verify --file pom.xml

--- a/docker/1.3/Dockerfile
+++ b/docker/1.3/Dockerfile
@@ -2,8 +2,6 @@
 # under LGPL 2.1 (LICENSE.TXT) Copyright 2020 Torsten Friebe <tfr@users.sourceforge.net>
 FROM tomcat:9.0-jdk11-temurin-jammy
 
-ENV LANG en_US.UTF-8
-
 # add build info labels that can be set on build
 # see also https://github.com/opencontainers/image-spec/blob/master/annotations.md
 ARG BUILD_DATE
@@ -15,7 +13,9 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
 LABEL maintainer="deegree TMC <tmc@deegree.org>"
 
 # set deegree OAF version
-ENV DEEGREE_OAF_VERSION=1.3-SNAPSHOT
+ARG DEEGREE_OAF_VERSION=1.3-SNAPSHOT
+
+ENV LANG en_US.UTF-8
 
 # tomcat port
 EXPOSE 8080


### PR DESCRIPTION
This PR re-enables the github actions workflow to push the docker image. Was deactivated.