### PR TITLE
Fixed text.slice for non string values

### DIFF
--- a/deegree-ogcapi-features/src/main/resources/feature.html
+++ b/deegree-ogcapi-features/src/main/resources/feature.html
@@ -257,8 +257,9 @@ var App = new Vue({
   },
   filters: {
     truncate: function (text, stop, suffix) {
-        if (!text) return text
-        return text.slice(0, stop) + (stop < text.length ? suffix || '...' : '')
+        if (text && typeof text === 'string' )
+            return text.slice(0, stop) + (stop < text.length ? suffix || '...' : '')
+        return text
     }
   },
   data: {

--- a/deegree-ogcapi-features/src/main/resources/features.html
+++ b/deegree-ogcapi-features/src/main/resources/features.html
@@ -397,8 +397,9 @@ new Vue({
   el: '#app',
   filters: {
     truncate: function (text, stop, suffix) {
-        if (!text) return text
-        return text.slice(0, stop) + (stop < text.length ? suffix || '...' : '')
+        if (text && typeof text === 'string' )
+            return text.slice(0, stop) + (stop < text.length ? suffix || '...' : '')
+        return text
     }
   },
   data() {


### PR DESCRIPTION
Prior to this PR the table of the features html view was empty if at least one feature contains a non-string property. The map contains the geometries of the features.
Ths PR fixes the  features and feature html view.