### PR TITLE
Fix serverUrl in OpenAPI document

### DIFF
--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/openapi/OafOpenApiFilter.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/openapi/OafOpenApiFilter.java
@@ -147,8 +147,8 @@ public class OafOpenApiFilter extends AbstractSpecFilter {
 		if (openAPI.getServers() == null || openAPI.getServers().isEmpty())
 			openAPI.addServersItem(new Server());
 		Server server = openAPI.getServers().get(0);
-		String relativePathToOpenApi = uriInfo.getBaseUriBuilder().path("datasets").path(datasetId).toString();
-		server.setUrl(relativePathToOpenApi);
+		String absolutePathToOpenApi = uriInfo.getBaseUriBuilder().path("datasets").path(datasetId).toString();
+		server.setUrl(absolutePathToOpenApi);
 	}
 
 

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/openapi/OafOpenApiFilter.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/openapi/OafOpenApiFilter.java
@@ -147,16 +147,11 @@ public class OafOpenApiFilter extends AbstractSpecFilter {
 		if (openAPI.getServers() == null || openAPI.getServers().isEmpty())
 			openAPI.addServersItem(new Server());
 		Server server = openAPI.getServers().get(0);
-        String relativePathToOpenApi = createRelativePathToOpenApi();
-        server.setUrl(relativePathToOpenApi);
+		String relativePathToOpenApi = uriInfo.getBaseUriBuilder().path("datasets").path(datasetId).toString();
+		server.setUrl(relativePathToOpenApi);
 	}
 
-	private String createRelativePathToOpenApi() {
-		String baseUriPath = uriInfo.getBaseUri().getPath();
-		if (!baseUriPath.endsWith("/"))
-			baseUriPath = baseUriPath + "/";
-		return baseUriPath + "datasets/" + datasetId;
-	}
+
 
     private void filterPaths( OpenAPI openAPI ) {
         Paths paths = openAPI.getPaths();

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/openapi/OafOpenApiFilter.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/openapi/OafOpenApiFilter.java
@@ -60,6 +60,7 @@ import org.deegree.services.oaf.workspace.configuration.OafDatasets;
 import org.slf4j.Logger;
 
 import javax.inject.Inject;
+import javax.ws.rs.core.UriInfo;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -117,6 +118,8 @@ public class OafOpenApiFilter extends AbstractSpecFilter {
 
     public static final String GEOMETRY_PROPERTY_NAME = "geometry";
 
+    private final UriInfo uriInfo;
+
     private final String datasetId;
 
     private final OafDatasetConfiguration datasetConfiguration;
@@ -124,10 +127,10 @@ public class OafOpenApiFilter extends AbstractSpecFilter {
     @Inject
     private DeegreeWorkspaceInitializer deegreeWorkspaceInitializer;
 
-    public OafOpenApiFilter( String datasetId, DeegreeWorkspaceInitializer deegreeWorkspaceInitializer )
-                    throws UnknownDatasetId {
+    public OafOpenApiFilter(UriInfo uriInfo, String datasetId,
+			DeegreeWorkspaceInitializer deegreeWorkspaceInitializer) throws UnknownDatasetId {
+        this.uriInfo = uriInfo;
         this.datasetId = datasetId;
-
         OafDatasets oafDatasets = deegreeWorkspaceInitializer.getOafDatasets();
         this.datasetConfiguration = oafDatasets.getDataset( datasetId );
     }
@@ -140,18 +143,20 @@ public class OafOpenApiFilter extends AbstractSpecFilter {
         return super.filterOpenAPI( openAPI, params, cookies, headers );
     }
 
-    private void filterServers( OpenAPI openAPI ) {
-        if ( openAPI.getServers() == null || openAPI.getServers().isEmpty() )
-            openAPI.addServersItem( new Server() );
-        Server server = openAPI.getServers().get( 0 );
-        StringBuilder url = new StringBuilder();
-        if ( server.getUrl() != null )
-            url.append( server.getUrl() );
-        if ( server.getUrl() == null || !server.getUrl().endsWith( "/" ) )
-            url.append( "/" );
-        url.append( "datasets/" ).append( datasetId );
-        server.setUrl( url.toString() );
-    }
+	private void filterServers(OpenAPI openAPI) {
+		if (openAPI.getServers() == null || openAPI.getServers().isEmpty())
+			openAPI.addServersItem(new Server());
+		Server server = openAPI.getServers().get(0);
+        String relativePathToOpenApi = createRelativePathToOpenApi();
+        server.setUrl(relativePathToOpenApi);
+	}
+
+	private String createRelativePathToOpenApi() {
+		String baseUriPath = uriInfo.getBaseUri().getPath();
+		if (!baseUriPath.endsWith("/"))
+			baseUriPath = baseUriPath + "/";
+		return baseUriPath + "datasets/" + datasetId;
+	}
 
     private void filterPaths( OpenAPI openAPI ) {
         Paths paths = openAPI.getPaths();

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/openapi/OpenApiCreator.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/openapi/OpenApiCreator.java
@@ -74,7 +74,7 @@ public class OpenApiCreator {
     @Inject
     private DeegreeWorkspaceInitializer deegreeWorkspaceInitializer;
 
-    public OpenAPI createOpenApi( HttpHeaders headers, String datasetId )
+    public OpenAPI createOpenApi(HttpHeaders headers, UriInfo uriInfo, String datasetId )
                     throws Exception {
         OpenAPI oas = createOpenApiDocument( datasetId );
         SwaggerConfiguration oasConfig = createSwaggerConfiguration( oas );
@@ -92,9 +92,9 @@ public class OpenApiCreator {
         if ( oas2 != null && ctx.getOpenApiConfiguration() != null
              && ctx.getOpenApiConfiguration().getFilterClass() != null ) {
             try {
-                OafOpenApiFilter filter = new OafOpenApiFilter( datasetId, deegreeWorkspaceInitializer );
+                OafOpenApiFilter filter = new OafOpenApiFilter( uriInfo, datasetId, deegreeWorkspaceInitializer );
                 SpecFilter f = new SpecFilter();
-                oas2 = f.filter( oas2, filter, getQueryParams( uriInfo.getQueryParameters() ), getCookies( headers ),
+                oas2 = f.filter( oas2, filter, getQueryParams( this.uriInfo.getQueryParameters() ), getCookies( headers ),
                                  getHeaders( headers ) );
             } catch ( Exception e ) {
                 LOG.error( "failed to load filter", e );
@@ -147,18 +147,8 @@ public class OpenApiCreator {
         DatasetMetadata metadata = oafConfiguration.getServiceMetadata();
         Info info = createInfo( metadata );
         OpenAPI oas = new OpenAPI();
-        addserver( oas );
         oas.info( info );
         return oas;
-    }
-
-    private void addserver( OpenAPI oas ) {
-        String contextPath = servletConfig.getServletContext().getContextPath();
-        if ( contextPath != null && !contextPath.isEmpty() ) {
-            Server server = new Server().url( contextPath );
-            List<Server> servers = Collections.singletonList( server );
-            oas.servers( servers );
-        }
     }
 
     private Info createInfo( DatasetMetadata metadata ) {

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/OpenApi.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/OpenApi.java
@@ -58,12 +58,12 @@ import static org.slf4j.LoggerFactory.getLogger;
  */
 @Path("/datasets/{datasetId}/api")
 public class OpenApi {
-	
+
 	/**
-	 * Name for parameter that allows enabling allowing all origins for CORS. 
+	 * Name for parameter that allows enabling allowing all origins for CORS.
 	 */
 	public static final String PARAMETER_CORS_ALLOWALL = "deegree.oaf.openapi.cors.allow_all";
-	
+
 	private final boolean corsAllowAll = TunableParameter.get(PARAMETER_CORS_ALLOWALL, false);
 
     private static final Logger LOG = getLogger( OpenApi.class );
@@ -84,28 +84,28 @@ public class OpenApi {
                     @PathParam("datasetId")
                                     String datasetId )
                     throws Exception {
-        return respondWithOpenApi( headers, datasetId, true );
+        return respondWithOpenApi( headers, uriInfo, datasetId, true );
     }
-    
+
     @GET
     @Produces({ APPLICATION_OPENAPI_YAML, APPLICATION_YAML })
     @Operation(operationId = "openApi", summary = "api documentation", description = "api documentation")
     @Tag(name = "Capabilities")
     public Response getOpenApiOpenApiYaml(
-                    @Context HttpHeaders headers,
-                    @Context UriInfo uriInfo,
-                    @PathParam("datasetId")
+			@Context HttpHeaders headers,
+			@Context UriInfo uriInfo,
+			@PathParam("datasetId")
                                     String datasetId )
                     throws Exception {
-        return respondWithOpenApi( headers, datasetId, false );
+        return respondWithOpenApi( headers, uriInfo, datasetId, false );
     }
 
-    private Response respondWithOpenApi(HttpHeaders headers, String datasetId, boolean json) throws Exception {
-    	OpenAPI openApi = this.openApiCreator.createOpenApi( headers, datasetId );
+    private Response respondWithOpenApi(HttpHeaders headers, UriInfo uriInfo, String datasetId, boolean json) throws Exception {
+    	OpenAPI openApi = this.openApiCreator.createOpenApi( headers, uriInfo, datasetId );
 
         if ( openApi == null )
             return Response.status( 404 ).build();
-        
+
         String rendered;
         if (json) {
         	rendered = Json.mapper().writeValueAsString( openApi );
@@ -113,7 +113,7 @@ public class OpenApi {
         else {
         	rendered = Yaml.mapper().writeValueAsString( openApi );
         }
-        
+
         ResponseBuilder resp = Response.status( Response.Status.OK )
         		.entity( rendered );
         if (corsAllowAll) {

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/filter/OafOpenApiFilterTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/filter/OafOpenApiFilterTest.java
@@ -21,24 +21,6 @@
  */
 package org.deegree.services.oaf.filter;
 
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.PathItem;
-import io.swagger.v3.oas.models.Paths;
-import io.swagger.v3.oas.models.media.ArraySchema;
-import io.swagger.v3.oas.models.media.Content;
-import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.parser.OpenAPIV3Parser;
-import org.deegree.services.oaf.openapi.OafOpenApiFilter;
-import org.deegree.services.oaf.workspace.DeegreeWorkspaceInitializer;
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.junit.Test;
-
-import javax.xml.namespace.QName;
-import java.net.URL;
-import java.util.Map;
-
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_XML;
 import static javax.ws.rs.core.MediaType.TEXT_HTML;
@@ -52,11 +34,49 @@ import static org.deegree.services.oaf.TestData.mockWorkspaceInitializer;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import javax.xml.namespace.QName;
+import java.net.URI;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import org.deegree.services.oaf.openapi.OafOpenApiFilter;
+import org.deegree.services.oaf.workspace.DeegreeWorkspaceInitializer;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
  */
 public class OafOpenApiFilterTest {
+
+	private static final String BASE_URI = "http://localhost:8081/deegree-services-oaf";
+
+	@Mock
+	static UriInfo uriInfo = mock(UriInfo.class);
+
+	@BeforeClass
+    public static void mockUriInfo(){
+        when(uriInfo.getBaseUri()).thenReturn(URI.create(BASE_URI));
+        when(uriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri(BASE_URI));
+    }
 
     @Test
     public void testFilterOperation()
@@ -67,7 +87,7 @@ public class OafOpenApiFilterTest {
 
         DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = mockWorkspaceInitializer();
 
-        OafOpenApiFilter filter = new OafOpenApiFilter( "oaf", deegreeWorkspaceInitializer );
+        OafOpenApiFilter filter = new OafOpenApiFilter( uriInfo, "oaf", deegreeWorkspaceInitializer );
         filter.filterOpenAPI( openAPI, null, null, null );
 
         Paths paths = openAPI.getPaths();
@@ -94,6 +114,10 @@ public class OafOpenApiFilterTest {
         assertThat( paths.get( "/collections/strassenbaumkataster/items/{featureId}" ),
                     hasResponseMediaType( APPLICATION_GEOJSON, APPLICATION_GML, APPLICATION_GML_32, APPLICATION_GML_SF0,
                                           APPLICATION_GML_SF2, TEXT_HTML ) );
+
+		List<Server> servers = openAPI.getServers();
+		assertThat(servers.size(), is(1));
+		assertThat(servers.get(0).getUrl(), is("/deegree-services-oaf/datasets/oaf"));
     }
 
     @Test
@@ -106,7 +130,7 @@ public class OafOpenApiFilterTest {
         DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = mockWorkspaceInitializer(
                                 new QName( "http://www.deegree.org/app", "KitaEinrichtungen" ) );
 
-        OafOpenApiFilter filter = new OafOpenApiFilter( "oaf", deegreeWorkspaceInitializer );
+        OafOpenApiFilter filter = new OafOpenApiFilter( uriInfo, "oaf", deegreeWorkspaceInitializer );
         filter.filterOpenAPI( openAPI, null, null, null );
 
         Paths paths = openAPI.getPaths();
@@ -133,6 +157,10 @@ public class OafOpenApiFilterTest {
         ArraySchema leistungsnameSchema = (ArraySchema) propertiesSchema.getProperties().get( "Leistungsname" );
         assertThat( leistungsnameSchema.getType(), is( "array" ) );
         assertThat( leistungsnameSchema.getItems().getType(), is( "string" ) );
+
+		List<Server> servers = openAPI.getServers();
+		assertThat(servers.size(), is(1));
+		assertThat(servers.get(0).getUrl(), is("/deegree-services-oaf/datasets/oaf"));
     }
 
     @Test
@@ -145,7 +173,7 @@ public class OafOpenApiFilterTest {
         DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = mockWorkspaceInitializer(
                                 new QName( "http://www.deegree.org/datasource/feature/sql", "Zuwanderung" ) );
 
-        OafOpenApiFilter filter = new OafOpenApiFilter( "oaf", deegreeWorkspaceInitializer );
+        OafOpenApiFilter filter = new OafOpenApiFilter( uriInfo, "oaf", deegreeWorkspaceInitializer );
         filter.filterOpenAPI( openAPI, null, null, null );
 
         Paths paths = openAPI.getPaths();
@@ -172,6 +200,10 @@ public class OafOpenApiFilterTest {
         Schema countryComplexItems = countryComplexSchema.getItems();
         assertThat( ( (Schema) countryComplexItems.getProperties().get( "name" ) ).getType(), is( "string" ) );
         assertThat( ( (Schema) countryComplexItems.getProperties().get( "pop" ) ).getType(), is( "number" ) );
+
+		List<Server> servers = openAPI.getServers();
+		assertThat(servers.size(), is(1));
+		assertThat(servers.get(0).getUrl(), is("/deegree-services-oaf/datasets/oaf"));
     }
 
     private Matcher<PathItem> hasResponseMediaType( String... mediaTypes ) {

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/filter/OafOpenApiFilterTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/filter/OafOpenApiFilterTest.java
@@ -74,8 +74,7 @@ public class OafOpenApiFilterTest {
 
 	@BeforeClass
     public static void mockUriInfo(){
-        when(uriInfo.getBaseUri()).thenReturn(URI.create(BASE_URI));
-        when(uriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri(BASE_URI));
+        when(uriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri(BASE_URI),UriBuilder.fromUri(BASE_URI),UriBuilder.fromUri(BASE_URI));
     }
 
     @Test
@@ -117,7 +116,7 @@ public class OafOpenApiFilterTest {
 
 		List<Server> servers = openAPI.getServers();
 		assertThat(servers.size(), is(1));
-		assertThat(servers.get(0).getUrl(), is("/deegree-services-oaf/datasets/oaf"));
+		assertThat(servers.get(0).getUrl(), is("http://localhost:8081/deegree-services-oaf/datasets/oaf"));
     }
 
     @Test
@@ -160,7 +159,7 @@ public class OafOpenApiFilterTest {
 
 		List<Server> servers = openAPI.getServers();
 		assertThat(servers.size(), is(1));
-		assertThat(servers.get(0).getUrl(), is("/deegree-services-oaf/datasets/oaf"));
+		assertThat(servers.get(0).getUrl(), is("http://localhost:8081/deegree-services-oaf/datasets/oaf"));
     }
 
     @Test
@@ -203,7 +202,7 @@ public class OafOpenApiFilterTest {
 
 		List<Server> servers = openAPI.getServers();
 		assertThat(servers.size(), is(1));
-		assertThat(servers.get(0).getUrl(), is("/deegree-services-oaf/datasets/oaf"));
+		assertThat(servers.get(0).getUrl(), is("http://localhost:8081/deegree-services-oaf/datasets/oaf"));
     }
 
     private Matcher<PathItem> hasResponseMediaType( String... mediaTypes ) {


### PR DESCRIPTION
Before this PR the context path was used as start of the relative serverUrl, followed by "dataset/{datasetId}". If an Apache Webserver or NGINX is used and the configuration does not include the context path the serverUrl was wrong. 
Example:
Requesting the OpenAPI document with https://ogc-api.server.de/datasets/test/api the OpenAPI document contains the serverUrl 'deegree-ogcapi/datasets/test/api'. The execution of requests with the Swagger UI results in invalid URLs: https://ogc-api.server.de/deegree-ogcapi/datasets/test/collections

This PR fixes the serverUrl in the OpenAPI document. Instead of the relative url an absolute url is used. Using the example above the serverUrl results in  https://ogc-api.server.de/datasets/test/ and execution of request with the Swagger UI is possible.