### PR TITLE
Removed trigger for push on main branch for pushing docker image

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -5,19 +5,17 @@ name: Docker Image CI
 on:
   schedule:
     - cron: "0 1 * * *"
-  push:
-    branches: [ "main" ]
 
 jobs:
-
   build-1_3:
+    # if: contains(github.event.head_commit.message, 'publish')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
This PR removes the trigger on pushes on main branch to prevent pushing immediatly after release build a push of a new docker image to the previous release tag.

Required merge order:
 - To be merged after PR #135 

Replaces PR #119 