### PR TITLE
Upgraded dependencies for deegree and swagger to latest bugfix version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1005,7 +1005,7 @@
           <plugin>
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
-            <version>12.0.2</version>
+            <version>12.1.0</version>
             <configuration>
               <cveValidForHours>24</cveValidForHours>
               <knownExploitedEnabled>false</knownExploitedEnabled>


### PR DESCRIPTION
This PR upgrades:

 - deegree to latest bug fix version 3.5.10
 - swagger to latest bug fix version 2.1.25

Also the OWASP dependency-check-maven plugin upgraded to [12.1.0](https://github.com/jeremylong/DependencyCheck/releases/tag/v12.1.0)