### PR TITLE
Support of FILTER parameters with T_AFTER

### DIFF
--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/cql2/Cql2FilterVisitor.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/cql2/Cql2FilterVisitor.java
@@ -21,14 +21,10 @@
  */
 package org.deegree.services.oaf.cql2;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
+import org.deegree.commons.tom.datetime.ISO8601Converter;
 import org.deegree.commons.tom.primitive.BaseType;
 import org.deegree.commons.tom.primitive.PrimitiveType;
 import org.deegree.commons.tom.primitive.PrimitiveValue;
@@ -304,19 +300,12 @@ public class Cql2FilterVisitor extends Cql2BaseVisitor {
 
 	@Override
 	public Object visitDateInstantString(Cql2Parser.DateInstantStringContext ctx) {
-		return Date.from(LocalDate.parse(ctx.getText().substring(1, ctx.getText().length() - 1))
-			.atStartOfDay()
-			.atZone(ZoneId.systemDefault())
-			.toInstant());
+		return ISO8601Converter.parseDate(ctx.getText().substring(1, ctx.getText().length() - 1));
 	}
 
 	@Override
 	public Object visitTimestampInstant(Cql2Parser.TimestampInstantContext ctx) {
-		return Date.from(LocalDateTime
-			.parse(ctx.getText().substring(11, ctx.getText().length() - 2),
-					DateTimeFormatter.ISO_INSTANT.withZone(ZoneId.systemDefault()))
-			.atZone(ZoneId.systemDefault())
-			.toInstant());
+		return ISO8601Converter.parseDateTime(ctx.getText().substring(11, ctx.getText().length() - 2));
 	}
 
 }

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/cql2/Cql2FilterVisitor.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/cql2/Cql2FilterVisitor.java
@@ -21,11 +21,25 @@
  */
 package org.deegree.services.oaf.cql2;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.deegree.commons.tom.primitive.BaseType;
+import org.deegree.commons.tom.primitive.PrimitiveType;
+import org.deegree.commons.tom.primitive.PrimitiveValue;
 import org.deegree.cs.coordinatesystems.ICRS;
 import org.deegree.filter.Expression;
+import org.deegree.filter.expression.Literal;
 import org.deegree.filter.expression.ValueReference;
 import org.deegree.filter.spatial.Intersects;
 import org.deegree.filter.spatial.SpatialOperator;
+import org.deegree.filter.temporal.After;
+import org.deegree.filter.temporal.TemporalOperator;
 import org.deegree.geometry.Geometry;
 import org.deegree.geometry.GeometryFactory;
 import org.deegree.geometry.primitive.LineString;
@@ -33,9 +47,6 @@ import org.deegree.geometry.primitive.LinearRing;
 import org.deegree.geometry.primitive.Point;
 import org.deegree.geometry.primitive.Polygon;
 import org.deegree.geometry.primitive.Ring;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
@@ -90,7 +101,7 @@ public class Cql2FilterVisitor extends Cql2BaseVisitor {
 		if (ctx.comparisonPredicate() != null)
 			throw new Cql2UnsupportedExpressionException("comparisonPredicate are currently not supported.");
 		if (ctx.temporalPredicate() != null)
-			throw new Cql2UnsupportedExpressionException("temporalPredicates are currently not supported.");
+			return ctx.temporalPredicate().accept(this);
 		if (ctx.arrayPredicate() != null)
 			throw new Cql2UnsupportedExpressionException("arrayPredicate are currently not supported.");
 		return ctx.spatialPredicate().accept(this);
@@ -250,6 +261,62 @@ public class Cql2FilterVisitor extends Cql2BaseVisitor {
 	@Override
 	public Double visitZCoord(Cql2Parser.ZCoordContext ctx) {
 		return Double.valueOf(ctx.getText());
+	}
+
+	@Override
+	public Object visitTemporalPredicate(Cql2Parser.TemporalPredicateContext ctx) {
+		String temporalFunctionType = ctx.TemporalFunction().getText().substring(2);
+		TemporalOperator.SubType type = TemporalOperator.SubType.valueOf(temporalFunctionType);
+		switch (type) {
+			case AFTER:
+				Expression propName = (Expression) ctx.temporalExpression(0).propertyName().accept(this);
+				Expression dateValue = (Expression) ctx.temporalExpression(1).temporalInstance().accept(this);
+				return new After(propName, dateValue);
+		}
+		throw new Cql2UnsupportedExpressionException("Unsupported geometry type " + type);
+	}
+
+	@Override
+	public Object visitTemporalInstance(Cql2Parser.TemporalInstanceContext ctx) {
+		if (ctx.intervalInstance() != null)
+			throw new Cql2UnsupportedExpressionException("intervalInstance are currently not supported.");
+		PrimitiveValue primitiveValue = (PrimitiveValue) ctx.instantInstance().accept(this);
+		return new Literal<>(primitiveValue, null);
+	}
+
+	@Override
+	public Object visitInstantInstance(Cql2Parser.InstantInstanceContext ctx) {
+		if (ctx.dateInstant() != null) {
+			Object date = ctx.dateInstant().accept(this);
+			return new PrimitiveValue(date, new PrimitiveType(BaseType.DATE));
+		}
+		if (ctx.timestampInstant() != null) {
+			Object dateTime = ctx.timestampInstant().accept(this);
+			return new PrimitiveValue(dateTime, new PrimitiveType(BaseType.DATE_TIME));
+		}
+		return super.visitInstantInstance(ctx);
+	}
+
+	@Override
+	public Object visitDateInstant(Cql2Parser.DateInstantContext ctx) {
+		return ctx.dateInstantString().accept(this);
+	}
+
+	@Override
+	public Object visitDateInstantString(Cql2Parser.DateInstantStringContext ctx) {
+		return Date.from(LocalDate.parse(ctx.getText().substring(1, ctx.getText().length() - 1))
+			.atStartOfDay()
+			.atZone(ZoneId.systemDefault())
+			.toInstant());
+	}
+
+	@Override
+	public Object visitTimestampInstant(Cql2Parser.TimestampInstantContext ctx) {
+		return Date.from(LocalDateTime
+			.parse(ctx.getText().substring(11, ctx.getText().length() - 2),
+					DateTimeFormatter.ISO_INSTANT.withZone(ZoneId.systemDefault()))
+			.atZone(ZoneId.systemDefault())
+			.toInstant());
 	}
 
 }

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/cql2/Cql2ParserTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/cql2/Cql2ParserTest.java
@@ -26,12 +26,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Calendar;
-import java.util.Date;
 
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.deegree.commons.tom.TypedObjectNode;
+import org.deegree.commons.tom.datetime.Date;
+import org.deegree.commons.tom.datetime.DateTime;
 import org.deegree.commons.tom.primitive.PrimitiveValue;
 import org.deegree.cs.coordinatesystems.ICRS;
 import org.deegree.cs.exceptions.UnknownCRSException;
@@ -221,8 +222,7 @@ public class Cql2ParserTest {
 		assertTrue(primitiveValue instanceof PrimitiveValue);
 		Object value = ((PrimitiveValue) primitiveValue).getValue();
 		assertTrue(value instanceof Date);
-		Calendar calendar = Calendar.getInstance();
-		calendar.setTime((Date) value);
+		Calendar calendar = ((Date) value).getCalendar();
 		assertEquals(2025, calendar.get(Calendar.YEAR));
 		assertEquals(APRIL, calendar.get(Calendar.MONTH));
 		assertEquals(14, calendar.get(Calendar.DAY_OF_MONTH));
@@ -244,9 +244,8 @@ public class Cql2ParserTest {
 		TypedObjectNode primitiveValue = ((Literal<?>) date).getValue();
 		assertTrue(primitiveValue instanceof PrimitiveValue);
 		Object value = ((PrimitiveValue) primitiveValue).getValue();
-		assertTrue(value instanceof Date);
-		Calendar calendar = Calendar.getInstance();
-		calendar.setTime((Date) value);
+		assertTrue(value instanceof DateTime);
+		Calendar calendar = ((DateTime) value).getCalendar();
 		assertEquals(2025, calendar.get(Calendar.YEAR));
 		assertEquals(APRIL, calendar.get(Calendar.MONTH));
 		assertEquals(14, calendar.get(Calendar.DAY_OF_MONTH));

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/cql2/Cql2ParserTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/cql2/Cql2ParserTest.java
@@ -21,15 +21,26 @@
  */
 package org.deegree.services.oaf.cql2;
 
+import static java.util.Calendar.APRIL;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Calendar;
+import java.util.Date;
+
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.deegree.commons.tom.TypedObjectNode;
+import org.deegree.commons.tom.primitive.PrimitiveValue;
 import org.deegree.cs.coordinatesystems.ICRS;
 import org.deegree.cs.exceptions.UnknownCRSException;
 import org.deegree.cs.persistence.CRSManager;
 import org.deegree.filter.Expression;
+import org.deegree.filter.expression.Literal;
 import org.deegree.filter.expression.ValueReference;
 import org.deegree.filter.spatial.Intersects;
+import org.deegree.filter.temporal.After;
 import org.deegree.geometry.Envelope;
 import org.deegree.geometry.Geometry;
 import org.deegree.geometry.multi.MultiGeometry;
@@ -40,9 +51,6 @@ import org.deegree.geometry.primitive.LineString;
 import org.deegree.geometry.primitive.Point;
 import org.deegree.geometry.primitive.Polygon;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
@@ -194,6 +202,54 @@ public class Cql2ParserTest {
 		assertEquals(((Envelope) geometry).getMin().get(1), 32.288087, 0.0001);
 		assertEquals(((Envelope) geometry).getMax().get(0), 37.319836, 0.0001);
 		assertEquals(((Envelope) geometry).getMax().get(1), 33.288087, 0.0001);
+	}
+
+	@Test
+	public void test_parse_T_AFTER_date() throws UnknownCRSException {
+		String after = "T_AFTER(testDate,DATE('2025-04-14'))";
+		Object visit = parseCql2(after);
+
+		assertTrue(visit instanceof After);
+
+		Expression param1 = ((After) visit).getParameter1();
+		assertTrue(param1 instanceof ValueReference);
+		assertEquals("testDate", ((ValueReference) param1).getAsText());
+
+		Expression date = ((After) visit).getParameter2();
+		assertTrue(date instanceof Literal);
+		TypedObjectNode primitiveValue = ((Literal<?>) date).getValue();
+		assertTrue(primitiveValue instanceof PrimitiveValue);
+		Object value = ((PrimitiveValue) primitiveValue).getValue();
+		assertTrue(value instanceof Date);
+		Calendar calendar = Calendar.getInstance();
+		calendar.setTime((Date) value);
+		assertEquals(2025, calendar.get(Calendar.YEAR));
+		assertEquals(APRIL, calendar.get(Calendar.MONTH));
+		assertEquals(14, calendar.get(Calendar.DAY_OF_MONTH));
+	}
+
+	@Test
+	public void test_parse_T_AFTER_timestamp() throws UnknownCRSException {
+		String after = "T_AFTER(testDate,TIMESTAMP('2025-04-14T08:59:30Z'))";
+		Object visit = parseCql2(after);
+
+		assertTrue(visit instanceof After);
+
+		Expression param1 = ((After) visit).getParameter1();
+		assertTrue(param1 instanceof ValueReference);
+		assertEquals("testDate", ((ValueReference) param1).getAsText());
+
+		Expression date = ((After) visit).getParameter2();
+		assertTrue(date instanceof Literal);
+		TypedObjectNode primitiveValue = ((Literal<?>) date).getValue();
+		assertTrue(primitiveValue instanceof PrimitiveValue);
+		Object value = ((PrimitiveValue) primitiveValue).getValue();
+		assertTrue(value instanceof Date);
+		Calendar calendar = Calendar.getInstance();
+		calendar.setTime((Date) value);
+		assertEquals(2025, calendar.get(Calendar.YEAR));
+		assertEquals(APRIL, calendar.get(Calendar.MONTH));
+		assertEquals(14, calendar.get(Calendar.DAY_OF_MONTH));
 	}
 
 	private static Object parseCql2(String intersects) throws UnknownCRSException {

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/cql2/Cql2ParserTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/cql2/Cql2ParserTest.java
@@ -25,7 +25,10 @@ import static java.util.Calendar.APRIL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import javax.xml.namespace.QName;
 import java.util.Calendar;
+import java.util.Collections;
+import java.util.List;
 
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CharStream;
@@ -33,6 +36,7 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.deegree.commons.tom.TypedObjectNode;
 import org.deegree.commons.tom.datetime.Date;
 import org.deegree.commons.tom.datetime.DateTime;
+import org.deegree.commons.tom.primitive.BaseType;
 import org.deegree.commons.tom.primitive.PrimitiveValue;
 import org.deegree.cs.coordinatesystems.ICRS;
 import org.deegree.cs.exceptions.UnknownCRSException;
@@ -51,6 +55,7 @@ import org.deegree.geometry.multi.MultiPolygon;
 import org.deegree.geometry.primitive.LineString;
 import org.deegree.geometry.primitive.Point;
 import org.deegree.geometry.primitive.Polygon;
+import org.deegree.services.oaf.workspace.configuration.FilterProperty;
 import org.junit.Test;
 
 /**
@@ -214,7 +219,8 @@ public class Cql2ParserTest {
 
 		Expression param1 = ((After) visit).getParameter1();
 		assertTrue(param1 instanceof ValueReference);
-		assertEquals("testDate", ((ValueReference) param1).getAsText());
+		assertEquals("testDate", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals("", ((ValueReference) param1).getAsQName().getNamespaceURI());
 
 		Expression date = ((After) visit).getParameter2();
 		assertTrue(date instanceof Literal);
@@ -237,7 +243,8 @@ public class Cql2ParserTest {
 
 		Expression param1 = ((After) visit).getParameter1();
 		assertTrue(param1 instanceof ValueReference);
-		assertEquals("testDate", ((ValueReference) param1).getAsText());
+		assertEquals("testDate", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals("", ((ValueReference) param1).getAsQName().getNamespaceURI());
 
 		Expression date = ((After) visit).getParameter2();
 		assertTrue(date instanceof Literal);
@@ -262,7 +269,9 @@ public class Cql2ParserTest {
 		Cql2Parser.BooleanExpressionContext cql2 = parser.booleanExpression();
 
 		ICRS filterCrs = CRSManager.lookup("urn:ogc:def:crs:OGC:1.3:CRS84");
-		Cql2FilterVisitor visitor = new Cql2FilterVisitor(filterCrs);
+		List<FilterProperty> filterProperties = Collections
+			.singletonList(new FilterProperty(new QName("testDate"), BaseType.DATE));
+		Cql2FilterVisitor visitor = new Cql2FilterVisitor(filterCrs, filterProperties);
 		return visitor.visit(cql2);
 	}
 


### PR DESCRIPTION
This PR enhances OGC API - Features - Part 3 by T_AFTER({propertyName},{temporalInstance}) with {temporalInstance} = {instantInstance} and {instantInstance} = {dateInstant} | {timestampInstant}