### PR TITLE
Upgraded dependencies deegree to 3.5.13 and maven plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -842,7 +842,7 @@
       <dependency>
         <groupId>org.xmlunit</groupId>
         <artifactId>xmlunit-core</artifactId>
-        <version>2.10.0</version>
+        <version>2.10.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -878,7 +878,7 @@
       <dependency>
         <groupId>io.swagger.parser.v3</groupId>
         <artifactId>swagger-parser-v3</artifactId>
-        <version>2.1.26</version>
+        <version>2.1.29</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -934,7 +934,7 @@
     <java.version>11</java.version>
     <site.dir>${user.home}/Sites</site.dir>
     <jersey-version>2.41</jersey-version>
-    <swagger-version>2.2.30</swagger-version>
+    <swagger-version>2.2.32</swagger-version>
     <swagger-ui-version>3.52.5</swagger-ui-version>
     <jackson-version>2.16.2</jackson-version>
     <deegree-version>3.5.13</deegree-version>

--- a/pom.xml
+++ b/pom.xml
@@ -937,7 +937,7 @@
     <swagger-version>2.2.30</swagger-version>
     <swagger-ui-version>3.52.5</swagger-ui-version>
     <jackson-version>2.16.2</jackson-version>
-    <deegree-version>3.5.12</deegree-version>
+    <deegree-version>3.5.13</deegree-version>
     <slf4j.version>1.7.36</slf4j.version>
     <log4j.version>2.23.1</log4j.version>
     <antlr.version>4.13.2</antlr.version>

--- a/pom.xml
+++ b/pom.xml
@@ -177,12 +177,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.1.3</version>
+          <version>3.1.4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.1.3</version>
+          <version>3.1.4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -192,7 +192,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.13.0</version>
+          <version>3.14.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -1010,7 +1010,7 @@
           <plugin>
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
-            <version>12.1.0</version>
+            <version>12.1.1</version>
             <configuration>
               <nvdValidForHours>24</nvdValidForHours>
               <knownExploitedEnabled>false</knownExploitedEnabled>


### PR DESCRIPTION
This PR upgrades deegree to 3.5.13 including changes introduced with PR https://github.com/deegree/deegree3/pull/1819 and https://github.com/deegree/deegree3/pull/1816

Upgraded dependencies:
- deegree webservices 3.5.13
- xmlunit 2.10.2
- swagger 2.1.29