### PR TITLE
Post release bumped docker to v1.3.6

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -25,4 +25,4 @@ jobs:
           context: ./docker/1.3
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: deegree/deegree-ogcapi:1.3,deegree/deegree-ogcapi:1.3.5,deegree/deegree-ogcapi:latest
+          tags: deegree/deegree-ogcapi:1.3,deegree/deegree-ogcapi:1.3.6,deegree/deegree-ogcapi:latest

--- a/docker/1.3/Dockerfile
+++ b/docker/1.3/Dockerfile
@@ -15,7 +15,7 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
 LABEL maintainer="deegree TMC <tmc@deegree.org>"
 
 # set deegree OAF version
-ENV DEEGREE_OAF_VERSION=1.3.5
+ENV DEEGREE_OAF_VERSION=1.3.6
 
 # tomcat port
 EXPOSE 8080

--- a/pom.xml
+++ b/pom.xml
@@ -842,7 +842,7 @@
       <dependency>
         <groupId>org.xmlunit</groupId>
         <artifactId>xmlunit-core</artifactId>
-        <version>2.10.0</version>
+        <version>2.10.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -878,7 +878,7 @@
       <dependency>
         <groupId>io.swagger.parser.v3</groupId>
         <artifactId>swagger-parser-v3</artifactId>
-        <version>2.1.26</version>
+        <version>2.1.29</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -934,7 +934,7 @@
     <java.version>11</java.version>
     <site.dir>${user.home}/Sites</site.dir>
     <jersey-version>2.41</jersey-version>
-    <swagger-version>2.2.30</swagger-version>
+    <swagger-version>2.2.32</swagger-version>
     <swagger-ui-version>3.52.5</swagger-ui-version>
     <jackson-version>2.16.2</jackson-version>
     <deegree-version>3.5.13</deegree-version>

--- a/pom.xml
+++ b/pom.xml
@@ -937,7 +937,7 @@
     <swagger-version>2.2.30</swagger-version>
     <swagger-ui-version>3.52.5</swagger-ui-version>
     <jackson-version>2.16.2</jackson-version>
-    <deegree-version>3.5.12</deegree-version>
+    <deegree-version>3.5.13</deegree-version>
     <slf4j.version>1.7.36</slf4j.version>
     <log4j.version>2.23.1</log4j.version>
     <antlr.version>4.13.2</antlr.version>

--- a/pom.xml
+++ b/pom.xml
@@ -177,12 +177,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.1.3</version>
+          <version>3.1.4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.1.3</version>
+          <version>3.1.4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -192,7 +192,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.13.0</version>
+          <version>3.14.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -1010,7 +1010,7 @@
           <plugin>
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
-            <version>12.1.0</version>
+            <version>12.1.1</version>
             <configuration>
               <nvdValidForHours>24</nvdValidForHours>
               <knownExploitedEnabled>false</knownExploitedEnabled>


### PR DESCRIPTION
This PR upgrades the docker file and the github actions build to v1.3.6