### PR TITLE
Implemented support of multiple geometries

### DIFF
--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/io/response/AbstractFeatureResponse.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/io/response/AbstractFeatureResponse.java
@@ -1,5 +1,7 @@
 package org.deegree.services.oaf.io.response;
 
+import javax.xml.namespace.QName;
+
 import org.deegree.services.oaf.io.SchemaLocation;
 import org.deegree.services.oaf.link.Link;
 
@@ -14,15 +16,21 @@ public abstract class AbstractFeatureResponse {
 
 	private final Map<String, String> featureTypeNsPrefixes;
 
+	private final QName geometryProperty;
+
+	private final boolean skipGeometryExportAsWkt;
+
 	private final String responseCrsName;
 
 	private final SchemaLocation schemaLocation;
 
 	private final List<Link> links;
 
-	AbstractFeatureResponse(Map<String, String> featureTypeNsPrefixes, String responseCrsName,
-			SchemaLocation schemaLocation, List<Link> links) {
+	AbstractFeatureResponse(Map<String, String> featureTypeNsPrefixes, QName geometryProperty,
+			boolean skipGeometryExportAsWkt, String responseCrsName, SchemaLocation schemaLocation, List<Link> links) {
 		this.featureTypeNsPrefixes = featureTypeNsPrefixes;
+		this.geometryProperty = geometryProperty;
+		this.skipGeometryExportAsWkt = skipGeometryExportAsWkt;
 		this.responseCrsName = responseCrsName;
 		this.schemaLocation = schemaLocation;
 		this.links = links;
@@ -37,6 +45,14 @@ public abstract class AbstractFeatureResponse {
 		if (featureTypeNsPrefixes == null)
 			return Collections.emptyMap();
 		return featureTypeNsPrefixes;
+	}
+
+	public QName getGeometryProperty() {
+		return geometryProperty;
+	}
+
+	public boolean isSkipGeometryExportAsWkt() {
+		return skipGeometryExportAsWkt;
 	}
 
 	public SchemaLocation getSchemaLocation() {

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/io/response/FeatureResponse.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/io/response/FeatureResponse.java
@@ -21,6 +21,8 @@
  */
 package org.deegree.services.oaf.io.response;
 
+import javax.xml.namespace.QName;
+
 import org.deegree.feature.Feature;
 import org.deegree.services.oaf.io.SchemaLocation;
 import org.deegree.services.oaf.link.Link;
@@ -35,9 +37,9 @@ public class FeatureResponse extends AbstractFeatureResponse {
 
 	private final Feature feature;
 
-	FeatureResponse(Feature feature, Map<String, String> featureTypeNsPrefixes, List<Link> links,
-			String responseCrsName, SchemaLocation schemaLocation) {
-		super(featureTypeNsPrefixes, responseCrsName, schemaLocation, links);
+	FeatureResponse(Feature feature, Map<String, String> featureTypeNsPrefixes, QName geometryProperty,
+			boolean skipGeometryExportAsWkt, List<Link> links, String responseCrsName, SchemaLocation schemaLocation) {
+		super(featureTypeNsPrefixes, geometryProperty, skipGeometryExportAsWkt, responseCrsName, schemaLocation, links);
 		this.feature = feature;
 	}
 

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/io/response/FeaturesResponse.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/io/response/FeaturesResponse.java
@@ -21,6 +21,8 @@
  */
 package org.deegree.services.oaf.io.response;
 
+import javax.xml.namespace.QName;
+
 import org.deegree.feature.stream.FeatureInputStream;
 import org.deegree.services.oaf.io.SchemaLocation;
 import org.deegree.services.oaf.link.Link;
@@ -43,10 +45,11 @@ public class FeaturesResponse extends AbstractFeatureResponse {
 
 	private final boolean isMaxFeaturesAndStartIndexApplicable;
 
-	FeaturesResponse(FeatureInputStream features, Map<String, String> featureTypeNsPrefixes, int numberOfFeatures,
-			int numberOfFeaturesMatched, int startIndex, List<Link> links, boolean isMaxFeaturesAndStartIndexApplicable,
-			String responseCrsName, SchemaLocation schemaLocation) {
-		super(featureTypeNsPrefixes, responseCrsName, schemaLocation, links);
+	FeaturesResponse(FeatureInputStream features, Map<String, String> featureTypeNsPrefixes, QName geometryProperty,
+			boolean skipGeometryExportAsWkt, int numberOfFeatures, int numberOfFeaturesMatched, int startIndex,
+			List<Link> links, boolean isMaxFeaturesAndStartIndexApplicable, String responseCrsName,
+			SchemaLocation schemaLocation) {
+		super(featureTypeNsPrefixes, geometryProperty, skipGeometryExportAsWkt, responseCrsName, schemaLocation, links);
 		this.features = features;
 		this.numberOfFeatures = numberOfFeatures;
 		this.numberOfFeaturesMatched = numberOfFeaturesMatched;

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/io/response/FeaturesResponseBuilder.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/io/response/FeaturesResponseBuilder.java
@@ -21,6 +21,8 @@
  */
 package org.deegree.services.oaf.io.response;
 
+import javax.xml.namespace.QName;
+
 import org.deegree.feature.Feature;
 import org.deegree.feature.stream.FeatureInputStream;
 import org.deegree.services.oaf.io.SchemaLocation;
@@ -41,6 +43,10 @@ public class FeaturesResponseBuilder {
 	private int numberOfFeaturesMatched;
 
 	private Map<String, String> featureTypeNsPrefixes;
+
+	private QName geometryProperty;
+
+	private boolean skipGeometryExportAsWkt;
 
 	private int numberOfFeatures;
 
@@ -68,6 +74,16 @@ public class FeaturesResponseBuilder {
 
 	public FeaturesResponseBuilder withFeatureTypeNsPrefixes(Map<String, String> featureTypeNsPrefixes) {
 		this.featureTypeNsPrefixes = featureTypeNsPrefixes;
+		return this;
+	}
+
+	public FeaturesResponseBuilder withGeometryProperty(QName geometryProperty) {
+		this.geometryProperty = geometryProperty;
+		return this;
+	}
+
+	public FeaturesResponseBuilder withSkipGeometryExportAsWkt(boolean skipGeometryExportAsWkt) {
+		this.skipGeometryExportAsWkt = skipGeometryExportAsWkt;
 		return this;
 	}
 
@@ -114,12 +130,14 @@ public class FeaturesResponseBuilder {
 	}
 
 	public FeaturesResponse buildFeaturesResponse() {
-		return new FeaturesResponse(features, featureTypeNsPrefixes, numberOfFeatures, numberOfFeaturesMatched,
-				startIndex, links, isMaxFeaturesAndStartIndexApplicable, responseCrsName, schemaLocation);
+		return new FeaturesResponse(features, featureTypeNsPrefixes, geometryProperty, skipGeometryExportAsWkt,
+				numberOfFeatures, numberOfFeaturesMatched, startIndex, links, isMaxFeaturesAndStartIndexApplicable,
+				responseCrsName, schemaLocation);
 	}
 
 	public FeatureResponse buildFeatureResponse() {
-		return new FeatureResponse(feature, featureTypeNsPrefixes, links, responseCrsName, schemaLocation);
+		return new FeatureResponse(feature, featureTypeNsPrefixes, geometryProperty, skipGeometryExportAsWkt, links,
+				responseCrsName, schemaLocation);
 	}
 
 }

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/io/response/geojson/AbstractFeatureResponseGeoJsonWriter.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/io/response/geojson/AbstractFeatureResponseGeoJsonWriter.java
@@ -46,7 +46,8 @@ public abstract class AbstractFeatureResponseGeoJsonWriter<T extends AbstractFea
 	public void writeTo(T feature, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
 			MultivaluedMap<String, Object> httpHeaders, OutputStream out) throws WebApplicationException {
 		try (Writer writer = new PrintWriter(out, false, UTF_8);
-				GeoJsonWriter geoJsonStreamWriter = new GeoJsonWriter(writer, asCrs(feature))) {
+				GeoJsonWriter geoJsonStreamWriter = new GeoJsonWriter(writer, asCrs(feature),
+						feature.getGeometryProperty(), feature.isSkipGeometryExportAsWkt())) {
 			writeContent(feature, geoJsonStreamWriter);
 		}
 		catch (Exception e) {
@@ -58,7 +59,7 @@ public abstract class AbstractFeatureResponseGeoJsonWriter<T extends AbstractFea
 	protected abstract void writeContent(T feature, GeoJsonWriter geoJsonStreamWriter)
 			throws IOException, TransformationException, UnknownCRSException, UnknownFeatureId;
 
-	protected ICRS asCrs(T feature) {
+	private ICRS asCrs(T feature) {
 		if (feature.getResponseCrsName() != null) {
 			CRSRef ref = CRSManager.getCRSRef(feature.getResponseCrsName());
 			ref.getReferencedObject(); // test if exists

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/DeegreeDataAccess.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/DeegreeDataAccess.java
@@ -38,10 +38,10 @@ import org.deegree.services.oaf.exceptions.InvalidConfigurationException;
 import org.deegree.services.oaf.exceptions.InvalidParameterValue;
 import org.deegree.services.oaf.exceptions.UnknownCollectionId;
 import org.deegree.services.oaf.exceptions.UnknownFeatureId;
+import org.deegree.services.oaf.io.request.FeaturesRequest;
 import org.deegree.services.oaf.io.response.FeatureResponse;
 import org.deegree.services.oaf.io.response.FeaturesResponse;
 import org.deegree.services.oaf.io.response.FeaturesResponseBuilder;
-import org.deegree.services.oaf.io.request.FeaturesRequest;
 import org.deegree.services.oaf.link.Link;
 import org.deegree.services.oaf.link.LinkBuilder;
 import org.deegree.services.oaf.link.NextLink;
@@ -116,6 +116,8 @@ public class DeegreeDataAccess implements DataAccess {
 			Map<String, String> featureTypeNsPrefixes = getFeatureTypeNsPrefixes(featureStore);
 			String namespaceURI = featureTypeMetadata.getName().getNamespaceURI();
 			return new FeaturesResponseBuilder(firstFeature).withFeatureTypeNsPrefixes(featureTypeNsPrefixes)
+				.withGeometryProperty(featureTypeMetadata.getGeometryProperty())
+				.withSkipGeometryExportAsWkt(featureTypeMetadata.isSkipGeometryExportAsWkt())
 				.withLinks(links)
 				.withResponseCrsName(crs)
 				.withSchemaLocation(namespaceURI, schemaLocation)
@@ -179,6 +181,8 @@ public class DeegreeDataAccess implements DataAccess {
 		String schemaLocation = linkBuilder.createSchemaLink(datasetId, collectionId);
 		String namespaceURI = featureTypeMetadata.getName().getNamespaceURI();
 		return new FeaturesResponseBuilder(features).withFeatureTypeNsPrefixes(featureTypeNsPrefixes)
+			.withGeometryProperty(featureTypeMetadata.getGeometryProperty())
+			.withSkipGeometryExportAsWkt(featureTypeMetadata.isSkipGeometryExportAsWkt())
 			.withNumberOfFeatures(limit)
 			.withNumberOfFeaturesMatched(numberOfFeaturesMatched)
 			.withStartIndex(offset)

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/configuration/FeatureTypeMetadata.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/configuration/FeatureTypeMetadata.java
@@ -38,6 +38,10 @@ public class FeatureTypeMetadata {
 
 	private QName dateTimeProperty;
 
+	private QName geometryProperty;
+
+	private boolean skipGeometryExportAsWkt;
+
 	private Extent extent;
 
 	private String title;
@@ -60,6 +64,16 @@ public class FeatureTypeMetadata {
 
 	public FeatureTypeMetadata dateTimeProperty(QName dateTimeProperty) {
 		this.dateTimeProperty = dateTimeProperty;
+		return this;
+	}
+
+	public FeatureTypeMetadata geometryProperty(QName geometryProperty) {
+		this.geometryProperty = geometryProperty;
+		return this;
+	}
+
+	public FeatureTypeMetadata skipGeometryExportAsWkt(boolean skipGeometryExportAsWkt) {
+		this.skipGeometryExportAsWkt = skipGeometryExportAsWkt;
 		return this;
 	}
 
@@ -113,6 +127,14 @@ public class FeatureTypeMetadata {
 
 	public QName getDateTimeProperty() {
 		return dateTimeProperty;
+	}
+
+	public QName getGeometryProperty() {
+		return geometryProperty;
+	}
+
+	public boolean isSkipGeometryExportAsWkt() {
+		return skipGeometryExportAsWkt;
 	}
 
 	public String getTitle() {

--- a/deegree-ogcapi-features/src/main/resources/META-INF/schemas/ogcapi/features.xsd
+++ b/deegree-ogcapi-features/src/main/resources/META-INF/schemas/ogcapi/features.xsd
@@ -23,6 +23,13 @@
             </sequence>
           </complexType>
         </element>
+        <element name="GeometryProperties" minOccurs="0">
+          <complexType>
+            <sequence>
+              <element name="GeometryProperty" type="oaf:GeometryPropertyType" maxOccurs="unbounded"/>
+            </sequence>
+          </complexType>
+        </element>
         <element name="HtmlViewId" type="string" minOccurs="0"/>
         <element name="Metadata" type="oaf:MetadataType" minOccurs="0"/>
         <element name="ConfigureCollection" minOccurs="0" maxOccurs="unbounded">
@@ -59,6 +66,14 @@
       <element name="FeatureTypeName" type="QName"/>
       <element name="PropertyName" type="QName"/>
     </sequence>
+  </complexType>
+
+  <complexType name="GeometryPropertyType">
+    <sequence>
+      <element name="FeatureTypeName" type="QName"/>
+      <element name="PropertyName" type="QName"/>
+    </sequence>
+    <attribute name="skipExportAsWkt" type="boolean" default="false"/>
   </complexType>
 
   <complexType name="MetadataType">


### PR DESCRIPTION
This PR implements support of FeatureTypes with multiple geometry  properties. The deegreeOAF confguration is enhanced by a `GeometryProperties` element, e.g.:
```
<GeometryProperties>
    <GeometryProperty skipExportAsWkt="false">
      <FeatureTypeName xmlns:app"http://deegree.org/app">app:TestFeatureType</FeatureTypeName>
      <PropertyName xmlns:app="http://deegree.org/app">app:geom1</PropertyName>
    </GeometryProperty>
  </GeometryProperties>
```

geom1 is exported as geometry in the GeoJSON. Other geometries are exported as WKT. With the attribute `skipExportAsWkt="true"` the export of geoemtries as WKT can be skipped. 

Requires PR https://github.com/deegree/deegree3/pull/1831