### PR TITLE
Fix requesting all data because property is not available

### DIFF
--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/cql2/Cql2FilterVisitor.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/cql2/Cql2FilterVisitor.java
@@ -26,6 +26,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.deegree.commons.tom.datetime.ISO8601Converter;
@@ -47,7 +48,6 @@ import org.deegree.geometry.primitive.LinearRing;
 import org.deegree.geometry.primitive.Point;
 import org.deegree.geometry.primitive.Polygon;
 import org.deegree.geometry.primitive.Ring;
-import org.deegree.services.oaf.workspace.configuration.FilterProperty;
 import org.slf4j.Logger;
 
 /**
@@ -59,13 +59,13 @@ public class Cql2FilterVisitor extends Cql2BaseVisitor {
 
 	private final ICRS filterCrs;
 
-	private final List<FilterProperty> filterProperties;
+	private final Set<QName> filterProperties;
 
 	/**
 	 * @param filterCrs never <code>null</code>
 	 * @param filterProperties
 	 */
-	public Cql2FilterVisitor(ICRS filterCrs, List<FilterProperty> filterProperties) {
+	public Cql2FilterVisitor(ICRS filterCrs, Set<QName> filterProperties) {
 		this.filterCrs = filterCrs;
 		this.filterProperties = filterProperties;
 	}
@@ -132,7 +132,6 @@ public class Cql2FilterVisitor extends Cql2BaseVisitor {
 	public Object visitPropertyName(Cql2Parser.PropertyNameContext ctx) {
 		String text = ctx.getText();
 		List<QName> filterPropWithSameLocalName = filterProperties.stream()
-			.map(FilterProperty::getName)
 			.filter(name -> name.getLocalPart().equals(text))
 			.collect(Collectors.toList());
 		if (!filterPropWithSameLocalName.isEmpty()) {
@@ -142,7 +141,7 @@ public class Cql2FilterVisitor extends Cql2BaseVisitor {
 						filterPropWithSameLocalName.get(0));
 			return new ValueReference(filterPropWithSameLocalName.get(0));
 		}
-		return new ValueReference(text, null);
+		throw new IllegalArgumentException("Property with name " + text + " is not supported.");
 	}
 
 	@Override

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/DeegreeQueryBuilder.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/DeegreeQueryBuilder.java
@@ -28,6 +28,7 @@ import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.antlr.v4.runtime.ANTLRInputStream;
@@ -38,6 +39,7 @@ import org.deegree.cs.coordinatesystems.ICRS;
 import org.deegree.cs.exceptions.UnknownCRSException;
 import org.deegree.cs.persistence.CRSManager;
 import org.deegree.feature.persistence.query.Query;
+import org.deegree.feature.types.AppSchemas;
 import org.deegree.filter.Expression;
 import org.deegree.filter.Filter;
 import org.deegree.filter.IdFilter;
@@ -175,8 +177,9 @@ public class DeegreeQueryBuilder {
 		parser.removeErrorListeners();
 		parser.addErrorListener(new Cql2ErrorListener());
 		Cql2Parser.BooleanExpressionContext cql2 = parser.booleanExpression();
-		Cql2FilterVisitor visitor = new Cql2FilterVisitor(lookupCrs(featuresRequest.getFilterCrs()),
-				featureTypeMetadata.getFilterProperties());
+		Set<QName> propertyNames = AppSchemas.collectProperyNames(featureTypeMetadata.getFeatureType().getSchema(),
+				featureTypeMetadata.getName());
+		Cql2FilterVisitor visitor = new Cql2FilterVisitor(lookupCrs(featuresRequest.getFilterCrs()), propertyNames);
 		return (Operator) visitor.visit(cql2);
 	}
 

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/cql2/Cql2ParserTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/cql2/Cql2ParserTest.java
@@ -27,8 +27,7 @@ import static org.junit.Assert.assertTrue;
 
 import javax.xml.namespace.QName;
 import java.util.Calendar;
-import java.util.Collections;
-import java.util.List;
+import java.util.Set;
 
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CharStream;
@@ -36,7 +35,6 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.deegree.commons.tom.TypedObjectNode;
 import org.deegree.commons.tom.datetime.Date;
 import org.deegree.commons.tom.datetime.DateTime;
-import org.deegree.commons.tom.primitive.BaseType;
 import org.deegree.commons.tom.primitive.PrimitiveValue;
 import org.deegree.cs.coordinatesystems.ICRS;
 import org.deegree.cs.exceptions.UnknownCRSException;
@@ -55,7 +53,6 @@ import org.deegree.geometry.multi.MultiPolygon;
 import org.deegree.geometry.primitive.LineString;
 import org.deegree.geometry.primitive.Point;
 import org.deegree.geometry.primitive.Polygon;
-import org.deegree.services.oaf.workspace.configuration.FilterProperty;
 import org.junit.Test;
 
 /**
@@ -72,7 +69,8 @@ public class Cql2ParserTest {
 
 		Expression param1 = ((Intersects) visit).getParam1();
 		assertTrue(param1 instanceof ValueReference);
-		assertEquals(((ValueReference) param1).getAsText(), "geometry");
+		assertEquals("geometry", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals("", ((ValueReference) param1).getAsQName().getNamespaceURI());
 
 		Geometry geometry = ((Intersects) visit).getGeometry();
 		assertTrue(geometry instanceof Point);
@@ -90,7 +88,8 @@ public class Cql2ParserTest {
 
 		Expression param1 = ((Intersects) visit).getParam1();
 		assertTrue(param1 instanceof ValueReference);
-		assertEquals(((ValueReference) param1).getAsText(), "geometry");
+		assertEquals("geometry", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals("", ((ValueReference) param1).getAsQName().getNamespaceURI());
 
 		Geometry geometry = ((Intersects) visit).getGeometry();
 		assertTrue(geometry instanceof LineString);
@@ -106,7 +105,8 @@ public class Cql2ParserTest {
 
 		Expression param1 = ((Intersects) visit).getParam1();
 		assertTrue(param1 instanceof ValueReference);
-		assertEquals(((ValueReference) param1).getAsText(), "geometry");
+		assertEquals("geometry", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals("", ((ValueReference) param1).getAsQName().getNamespaceURI());
 
 		Geometry geometry = ((Intersects) visit).getGeometry();
 		assertTrue(geometry instanceof Polygon);
@@ -123,7 +123,8 @@ public class Cql2ParserTest {
 
 		Expression param1 = ((Intersects) visit).getParam1();
 		assertTrue(param1 instanceof ValueReference);
-		assertEquals(((ValueReference) param1).getAsText(), "geometry");
+		assertEquals("geometry", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals("", ((ValueReference) param1).getAsQName().getNamespaceURI());
 
 		Geometry geometry = ((Intersects) visit).getGeometry();
 		assertTrue(geometry instanceof MultiPoint);
@@ -143,7 +144,8 @@ public class Cql2ParserTest {
 
 		Expression param1 = ((Intersects) visit).getParam1();
 		assertTrue(param1 instanceof ValueReference);
-		assertEquals(((ValueReference) param1).getAsText(), "geometry");
+		assertEquals("geometry", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals("", ((ValueReference) param1).getAsQName().getNamespaceURI());
 
 		Geometry geometry = ((Intersects) visit).getGeometry();
 		assertTrue(geometry instanceof MultiLineString);
@@ -161,7 +163,8 @@ public class Cql2ParserTest {
 
 		Expression param1 = ((Intersects) visit).getParam1();
 		assertTrue(param1 instanceof ValueReference);
-		assertEquals(((ValueReference) param1).getAsText(), "geometry");
+		assertEquals("geometry", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals("", ((ValueReference) param1).getAsQName().getNamespaceURI());
 
 		Geometry geometry = ((Intersects) visit).getGeometry();
 		assertTrue(geometry instanceof MultiPolygon);
@@ -181,7 +184,8 @@ public class Cql2ParserTest {
 
 		Expression param1 = ((Intersects) visit).getParam1();
 		assertTrue(param1 instanceof ValueReference);
-		assertEquals(((ValueReference) param1).getAsText(), "geometry");
+		assertEquals("geometry", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals("", ((ValueReference) param1).getAsQName().getNamespaceURI());
 
 		Geometry geometry = ((Intersects) visit).getGeometry();
 		assertTrue(geometry instanceof MultiGeometry);
@@ -200,7 +204,8 @@ public class Cql2ParserTest {
 
 		Expression param1 = ((Intersects) visit).getParam1();
 		assertTrue(param1 instanceof ValueReference);
-		assertEquals(((ValueReference) param1).getAsText(), "geometry");
+		assertEquals("geometry", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals("", ((ValueReference) param1).getAsQName().getNamespaceURI());
 
 		Geometry geometry = ((Intersects) visit).getGeometry();
 		assertTrue(geometry instanceof Envelope);
@@ -269,8 +274,7 @@ public class Cql2ParserTest {
 		Cql2Parser.BooleanExpressionContext cql2 = parser.booleanExpression();
 
 		ICRS filterCrs = CRSManager.lookup("urn:ogc:def:crs:OGC:1.3:CRS84");
-		List<FilterProperty> filterProperties = Collections
-			.singletonList(new FilterProperty(new QName("testDate"), BaseType.DATE));
+		Set<QName> filterProperties = Set.of(new QName("testDate"), new QName("geometry"));
 		Cql2FilterVisitor visitor = new Cql2FilterVisitor(filterCrs, filterProperties);
 		return visitor.visit(cql2);
 	}


### PR DESCRIPTION
This PR fixes long running queries when all data are requested, because the requested property is not available. 
Requested properties used in the CQL2_FILTER are checked against properties from appschema. If the property is not available an exception is thrown. Before the properties was checked against the available queryables (only primitive properties) and a default (text without namespace URI ) was returned. An UnmappableException was thrown and the WHERE clause was empty. 