### PR TITLE
Separated parsing metadata from metadata and configMetadata

### DIFF
--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/configuration/DatasetMetadata.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/configuration/DatasetMetadata.java
@@ -66,9 +66,11 @@ public class DatasetMetadata {
 		if (metadata != null) {
 			this.title = getTitle(metadata);
 			this.description = getDescription(metadata);
+			parseProviderContact(metadata.getServiceProvider());
+		}
+		if (configMetadata != null) {
 			parseLicenses(configMetadata);
 			parseDatasetContact(configMetadata);
-			parseProviderContact(metadata.getServiceProvider());
 			parseMetadataUrls(configMetadata);
 		}
 	}


### PR DESCRIPTION
This PR fixes a problem when parsing the metadata section. Before, a `*_metadata.xml` file was required to parse metadata and other elements from deegreeOAF configuration file. With the fix the metadata is not required anymore and other sections like license are parsed.