### PR TITLE
Upgraded dependencies deegree to 3.5.14 and maven plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -842,13 +842,13 @@
       <dependency>
         <groupId>org.xmlunit</groupId>
         <artifactId>xmlunit-core</artifactId>
-        <version>2.10.2</version>
+        <version>2.10.3</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.xmlunit</groupId>
         <artifactId>xmlunit-matchers</artifactId>
-        <version>2.9.1</version>
+        <version>2.10.3</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -878,7 +878,7 @@
       <dependency>
         <groupId>io.swagger.parser.v3</groupId>
         <artifactId>swagger-parser-v3</artifactId>
-        <version>2.1.29</version>
+        <version>2.1.31</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -934,10 +934,10 @@
     <java.version>11</java.version>
     <site.dir>${user.home}/Sites</site.dir>
     <jersey-version>2.41</jersey-version>
-    <swagger-version>2.2.32</swagger-version>
+    <swagger-version>2.2.34</swagger-version>
     <swagger-ui-version>3.52.5</swagger-ui-version>
     <jackson-version>2.16.2</jackson-version>
-    <deegree-version>3.5.13</deegree-version>
+    <deegree-version>3.5.14</deegree-version>
     <slf4j.version>1.7.36</slf4j.version>
     <log4j.version>2.23.1</log4j.version>
     <antlr.version>4.13.2</antlr.version>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.6.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -241,7 +241,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.0</version>
         </plugin>
         <plugin>
           <groupId>org.antlr</groupId>
@@ -461,7 +461,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>2.4.0</version>
+        <version>2.6.0</version>
       </plugin>
       <plugin>
         <groupId>io.spring.javaformat</groupId>
@@ -961,7 +961,7 @@
           <plugin>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-maven-plugin</artifactId>
-            <version>4.8.6.5</version>
+            <version>4.9.3.2</version>
             <configuration>
               <xmlOutput>true</xmlOutput>
               <findbugsXmlWithMessages>true</findbugsXmlWithMessages>
@@ -1010,7 +1010,7 @@
           <plugin>
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
-            <version>12.1.1</version>
+            <version>12.1.3</version>
             <configuration>
               <nvdValidForHours>24</nvdValidForHours>
               <knownExploitedEnabled>false</knownExploitedEnabled>


### PR DESCRIPTION
This PR upgrades the dependencies:
- swagger to 2.2.34
- deegree core api to 3.5.14
- and maven plugins