### PR TITLE
Improved documentation about usage of ConfigureCollection element

### DIFF
--- a/deegree-ogcapi-documentation/src/main/asciidoc/configuration.adoc
+++ b/deegree-ogcapi-documentation/src/main/asciidoc/configuration.adoc
@@ -192,12 +192,13 @@ The next example shows a complete configuration for a dataset called "trees" wit
     <MetadataURL format="text/html">http://example.metadata.org/path_to_html/1234</MetadataURL> <!--11-->
   </Metadata>
 
-  <ConfigureCollection id="SimpleFeature"> <!--12-->
-    <AddLink href="https://inspire.ec.europa.eu/featureconcept/XXX" rel="tag" type="text/html" title="Feature concept XXX"/>
+  <ConfigureCollection id="TreeFeature"> <!--12-->
+    <AddLink href="https://inspire.ec.europa.eu/featureconcept/" rel="tag" type="text/html" title="Feature concept for trees"/>
   </ConfigureCollection>
 
-  <ConfigureCollections> <!--13-->
-    <AddLink href="https://github.com/INSPIRE-MIF/XXX" rel="describedby" type="text/html" title="Encoding description"/>
+  <ConfigureCollections>
+    <AddLink href="https://github.com/INSPIRE-MIF/" rel="describedby" type="text/html" title="Encoding example"/> <!--13-->
+    <AddLink href="https://schemas.deegree.org/trees.xsd" rel="describedby" type="application/xml" title="GML application schema for trees"/> <!--14-->
   </ConfigureCollections>
 
 </deegreeOAF>
@@ -215,6 +216,7 @@ The next example shows a complete configuration for a dataset called "trees" wit
 <11> metadata link in format `text/html` for the dataset (optional)
 <12> configure additional links for an individual collection. In the example, an additional link to the INSPIRE feature concept for the collection is provided (optional) (required by INSPIRE)
 <13> configure additional links for all collections. In the example, an additional link to the alternative encoding description for collections is provided (optional) (recommended by INSPIRE)
+<14> configure additional links for all collections. In the example, an additional link to the GML application schema is provided (optional) (used by tools such as QGIS and GDAL)
 
 NOTE: The dataset configuration file must be stored in the subdirectory _ogcapi/_. The file is mandatory.
 


### PR DESCRIPTION
This PR improves the documentation about usage of ConfigureCollection element about usage for describedBy ref link to link a GML schema as described in:
- https://github.com/INSPIRE-MIF/gp-ogc-api-features/blob/master/spec/oapif-inspire-download.md
- https://docs.ogc.org/is/17-069r4/17-069r4.html