### PR TITLE
Support simple XSD types as queryable

### DIFF
--- a/deegree-ogcapi-documentation/src/main/asciidoc/usage.adoc
+++ b/deegree-ogcapi-documentation/src/main/asciidoc/usage.adoc
@@ -184,7 +184,7 @@ The following query parameters are supported when using HTTP GET:
 |`limit` |integer |10 |Limit the numbers of items per page
 |`offset` |integer |0 |Start index of items
 |`bulk` |boolean |true |Applicable for features resource only, can be combined with parameter `f`
-|`filter`|String |S_INTERSECTS({spatialQueryable},{spatialInstance}) |Filter limited to `S_INTERSECTS` with first operand `{spatialQueryable}` defining the property name and the second operand `{spatialInstance}` the basic spatial data type point or bounding box.
+|`filter`|String |S_INTERSECTS({spatialQueryable},{spatialInstance}), T_AFTER({temporalQueryable},{temporalInstance}) |Filter limited to `S_INTERSECTS` with first operand `{spatialQueryable}` defining the property name and the second operand `{spatialInstance}` the basic spatial data type point or bounding box. Filter limited to `T_AFTER` with first operand `{temporalQueryable}` defining the property name and the second operand `{temporalInstance}` with a date `DATE('2026-01-01')` or datetime `TIMESTAMP('2025-04-14T08:59:30Z')`. Available `{temporalQueryable}` are listed as additionale queryable in the  <<openapi>> document (type `date` or `date-time`), see note below.
 |`filter-lang`|String |cql2-text |Defines the filtering language, indicates that the value of the `filter` parameter is the text encoding of CQL2, can be combined with parameter `filter`
 |`filter-crs`|String | EPSG:4326 |Allows clients to assert which CRS is being used to encode geometric values in a `filter` expression, can be combined with parameter `filter`
 |===

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/OafResource.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/OafResource.java
@@ -50,6 +50,7 @@ import org.deegree.services.oaf.exceptions.InvalidConfigurationException;
 import org.deegree.services.oaf.workspace.configuration.DatasetMetadata;
 import org.deegree.services.oaf.workspace.configuration.FeatureTypeMetadata;
 import org.deegree.services.oaf.workspace.configuration.FilterProperty;
+import org.deegree.services.oaf.workspace.configuration.FilterPropertyType;
 import org.deegree.services.oaf.workspace.configuration.OafDatasetConfiguration;
 import org.deegree.services.ogcapi.features.DateTimePropertyType;
 import org.deegree.services.ogcapi.features.DeegreeOAF;
@@ -298,7 +299,10 @@ public class OafResource implements Resource {
 				PrimitiveType primitiveType = ((SimplePropertyType) propertyDeclaration).getPrimitiveType();
 				BaseType baseType = primitiveType.getBaseType();
 				QName propertyName = propertyDeclaration.getName();
-				filterProperties.add(new FilterProperty(propertyName, baseType));
+				filterProperties.add(new FilterProperty(propertyName, FilterPropertyType.fromBaseType(baseType)));
+			}
+			else if (propertyDeclaration instanceof org.deegree.feature.types.property.GeometryPropertyType) {
+				filterProperties.add(new FilterProperty(propertyDeclaration.getName(), FilterPropertyType.GEOMETRY));
 			}
 		});
 		return filterProperties;

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/cql2/Cql2FilterVisitor.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/cql2/Cql2FilterVisitor.java
@@ -26,6 +26,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.deegree.commons.tom.datetime.ISO8601Converter;
@@ -47,7 +48,6 @@ import org.deegree.geometry.primitive.LinearRing;
 import org.deegree.geometry.primitive.Point;
 import org.deegree.geometry.primitive.Polygon;
 import org.deegree.geometry.primitive.Ring;
-import org.deegree.services.oaf.workspace.configuration.FilterProperty;
 import org.slf4j.Logger;
 
 /**
@@ -59,13 +59,13 @@ public class Cql2FilterVisitor extends Cql2BaseVisitor {
 
 	private final ICRS filterCrs;
 
-	private final List<FilterProperty> filterProperties;
+	private final Set<QName> filterProperties;
 
 	/**
 	 * @param filterCrs never <code>null</code>
 	 * @param filterProperties
 	 */
-	public Cql2FilterVisitor(ICRS filterCrs, List<FilterProperty> filterProperties) {
+	public Cql2FilterVisitor(ICRS filterCrs, Set<QName> filterProperties) {
 		this.filterCrs = filterCrs;
 		this.filterProperties = filterProperties;
 	}
@@ -132,7 +132,6 @@ public class Cql2FilterVisitor extends Cql2BaseVisitor {
 	public Object visitPropertyName(Cql2Parser.PropertyNameContext ctx) {
 		String text = ctx.getText();
 		List<QName> filterPropWithSameLocalName = filterProperties.stream()
-			.map(FilterProperty::getName)
 			.filter(name -> name.getLocalPart().equals(text))
 			.collect(Collectors.toList());
 		if (!filterPropWithSameLocalName.isEmpty()) {
@@ -142,7 +141,7 @@ public class Cql2FilterVisitor extends Cql2BaseVisitor {
 						filterPropWithSameLocalName.get(0));
 			return new ValueReference(filterPropWithSameLocalName.get(0));
 		}
-		return new ValueReference(text, null);
+		throw new IllegalArgumentException("Property with name " + text + " is not supported.");
 	}
 
 	@Override

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/cql2/Cql2FilterVisitor.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/cql2/Cql2FilterVisitor.java
@@ -21,12 +21,16 @@
  */
 package org.deegree.services.oaf.cql2;
 
+import static org.deegree.services.oaf.workspace.configuration.FilterPropertyType.DATE;
+import static org.deegree.services.oaf.workspace.configuration.FilterPropertyType.DATE_TIME;
+import static org.deegree.services.oaf.workspace.configuration.FilterPropertyType.TIME;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import javax.xml.namespace.QName;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.deegree.commons.tom.datetime.ISO8601Converter;
@@ -48,6 +52,8 @@ import org.deegree.geometry.primitive.LinearRing;
 import org.deegree.geometry.primitive.Point;
 import org.deegree.geometry.primitive.Polygon;
 import org.deegree.geometry.primitive.Ring;
+import org.deegree.services.oaf.workspace.configuration.FilterProperty;
+import org.deegree.services.oaf.workspace.configuration.FilterPropertyType;
 import org.slf4j.Logger;
 
 /**
@@ -59,13 +65,13 @@ public class Cql2FilterVisitor extends Cql2BaseVisitor {
 
 	private final ICRS filterCrs;
 
-	private final Set<QName> filterProperties;
+	private final List<FilterProperty> filterProperties;
 
 	/**
 	 * @param filterCrs never <code>null</code>
 	 * @param filterProperties
 	 */
-	public Cql2FilterVisitor(ICRS filterCrs, Set<QName> filterProperties) {
+	public Cql2FilterVisitor(ICRS filterCrs, List<FilterProperty> filterProperties) {
 		this.filterCrs = filterCrs;
 		this.filterProperties = filterProperties;
 	}
@@ -121,9 +127,10 @@ public class Cql2FilterVisitor extends Cql2BaseVisitor {
 		SpatialOperator.SubType type = SpatialOperator.SubType.valueOf(spatialFunctionType);
 		switch (type) {
 			case INTERSECTS:
-				Expression propeName = (Expression) ctx.geomExpression().get(0).accept(this);
+				Expression propName = checkExpressionType((Expression) ctx.geomExpression().get(0).accept(this),
+						FilterPropertyType.GEOMETRY);
 				Geometry geometry = (Geometry) ctx.geomExpression().get(1).accept(this);
-				return new Intersects(propeName, geometry);
+				return new Intersects(propName, geometry);
 		}
 		throw new Cql2UnsupportedExpressionException("Unsupported geometry type " + type);
 	}
@@ -132,7 +139,8 @@ public class Cql2FilterVisitor extends Cql2BaseVisitor {
 	public Object visitPropertyName(Cql2Parser.PropertyNameContext ctx) {
 		String text = ctx.getText();
 		List<QName> filterPropWithSameLocalName = filterProperties.stream()
-			.filter(name -> name.getLocalPart().equals(text))
+			.filter(propName -> propName.getName().getLocalPart().equals(text))
+			.map(FilterProperty::getName)
 			.collect(Collectors.toList());
 		if (!filterPropWithSameLocalName.isEmpty()) {
 			if (filterPropWithSameLocalName.size() > 1)
@@ -287,7 +295,8 @@ public class Cql2FilterVisitor extends Cql2BaseVisitor {
 		TemporalOperator.SubType type = TemporalOperator.SubType.valueOf(temporalFunctionType);
 		switch (type) {
 			case AFTER:
-				Expression propName = (Expression) ctx.temporalExpression(0).propertyName().accept(this);
+				Expression propName = checkExpressionType(
+						(Expression) ctx.temporalExpression(0).propertyName().accept(this), DATE, DATE_TIME, TIME);
 				Expression dateValue = (Expression) ctx.temporalExpression(1).temporalInstance().accept(this);
 				return new After(propName, dateValue);
 		}
@@ -328,6 +337,23 @@ public class Cql2FilterVisitor extends Cql2BaseVisitor {
 	@Override
 	public Object visitTimestampInstant(Cql2Parser.TimestampInstantContext ctx) {
 		return ISO8601Converter.parseDateTime(ctx.getText().substring(11, ctx.getText().length() - 2));
+	}
+
+	private Expression checkExpressionType(Expression expression, FilterPropertyType... filterPropertyTypes)
+			throws IllegalArgumentException {
+		if (expression instanceof ValueReference) {
+			Optional<FilterProperty> filterProperty = filterProperties.stream()
+				.filter(fp -> fp.getName().equals(((ValueReference) expression).getAsQName()))
+				.findFirst();
+			if (filterProperty.isPresent()
+					&& Arrays.stream(filterPropertyTypes).noneMatch(fp -> fp == filterProperty.get().getType()))
+				throw new IllegalArgumentException(
+						"Property " + filterProperty.get().getName() + " is not of one of the expected types "
+								+ Arrays.stream(filterPropertyTypes)
+									.map(FilterPropertyType::name)
+									.collect(Collectors.joining(",")));
+		}
+		return expression;
 	}
 
 }

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/openapi/OafOpenApiFilter.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/openapi/OafOpenApiFilter.java
@@ -591,6 +591,10 @@ public class OafOpenApiFilter extends AbstractSpecFilter {
 				return "integer";
 			case BOOLEAN:
 				return "boolean";
+			case DATE:
+				return "date";
+			case DATE_TIME:
+				return "date-time";
 			case STRING:
 			default:
 				return "string";

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/openapi/OafOpenApiFilter.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/openapi/OafOpenApiFilter.java
@@ -55,6 +55,7 @@ import org.deegree.services.oaf.exceptions.UnknownDatasetId;
 import org.deegree.services.oaf.workspace.DeegreeWorkspaceInitializer;
 import org.deegree.services.oaf.workspace.configuration.FeatureTypeMetadata;
 import org.deegree.services.oaf.workspace.configuration.FilterProperty;
+import org.deegree.services.oaf.workspace.configuration.FilterPropertyType;
 import org.deegree.services.oaf.workspace.configuration.OafDatasetConfiguration;
 import org.deegree.services.oaf.workspace.configuration.OafDatasets;
 import org.slf4j.Logger;
@@ -232,7 +233,7 @@ public class OafOpenApiFilter extends AbstractSpecFilter {
 		if (filterProperties == null)
 			return;
 		List<Parameter> parameters = pathItem.getGet().getParameters();
-		filterProperties.forEach(filterProperty -> {
+		filterProperties.stream().filter(fp -> fp.getType() != FilterPropertyType.GEOMETRY).forEach(filterProperty -> {
 			Parameter filterParameter = new Parameter().name(filterProperty.getName().getLocalPart())
 				.description(descriptionByParameterType(filterProperty))
 				.in("query")
@@ -582,7 +583,7 @@ public class OafOpenApiFilter extends AbstractSpecFilter {
 	}
 
 	private String mapToParameterType(FilterProperty filterProperty) {
-		BaseType type = filterProperty.getType();
+		FilterPropertyType type = filterProperty.getType();
 		switch (type) {
 			case DOUBLE:
 			case DECIMAL:
@@ -602,7 +603,7 @@ public class OafOpenApiFilter extends AbstractSpecFilter {
 	}
 
 	private String descriptionByParameterType(FilterProperty filterProperty) {
-		BaseType type = filterProperty.getType();
+		FilterPropertyType type = filterProperty.getType();
 		switch (type) {
 			case DOUBLE:
 			case DECIMAL:

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/DeegreeQueryBuilder.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/DeegreeQueryBuilder.java
@@ -28,7 +28,6 @@ import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.antlr.v4.runtime.ANTLRInputStream;
@@ -39,7 +38,6 @@ import org.deegree.cs.coordinatesystems.ICRS;
 import org.deegree.cs.exceptions.UnknownCRSException;
 import org.deegree.cs.persistence.CRSManager;
 import org.deegree.feature.persistence.query.Query;
-import org.deegree.feature.types.AppSchemas;
 import org.deegree.filter.Expression;
 import org.deegree.filter.Filter;
 import org.deegree.filter.IdFilter;
@@ -178,10 +176,7 @@ public class DeegreeQueryBuilder {
 		parser.addErrorListener(new Cql2ErrorListener());
 		Cql2Parser.BooleanExpressionContext cql2 = parser.booleanExpression();
 		Cql2FilterVisitor visitor = new Cql2FilterVisitor(lookupCrs(featuresRequest.getFilterCrs()),
-				featureTypeMetadata.getFilterProperties()
-					.stream()
-					.map(FilterProperty::getName)
-					.collect(Collectors.toSet()));
+				featureTypeMetadata.getFilterProperties());
 		return (Operator) visitor.visit(cql2);
 	}
 

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/DeegreeQueryBuilder.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/DeegreeQueryBuilder.java
@@ -28,6 +28,7 @@ import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.antlr.v4.runtime.ANTLRInputStream;
@@ -38,6 +39,7 @@ import org.deegree.cs.coordinatesystems.ICRS;
 import org.deegree.cs.exceptions.UnknownCRSException;
 import org.deegree.cs.persistence.CRSManager;
 import org.deegree.feature.persistence.query.Query;
+import org.deegree.feature.types.AppSchemas;
 import org.deegree.filter.Expression;
 import org.deegree.filter.Filter;
 import org.deegree.filter.IdFilter;
@@ -175,8 +177,9 @@ public class DeegreeQueryBuilder {
 		parser.removeErrorListeners();
 		parser.addErrorListener(new Cql2ErrorListener());
 		Cql2Parser.BooleanExpressionContext cql2 = parser.booleanExpression();
-		Cql2FilterVisitor visitor = new Cql2FilterVisitor(lookupCrs(featuresRequest.getFilterCrs()),
-				featureTypeMetadata.getFilterProperties());
+		Set<QName> propertyNames = AppSchemas.collectProperyNames(featureTypeMetadata.getFeatureType().getSchema(),
+				featureTypeMetadata.getName());
+		Cql2FilterVisitor visitor = new Cql2FilterVisitor(lookupCrs(featuresRequest.getFilterCrs()), propertyNames);
 		return (Operator) visitor.visit(cql2);
 	}
 

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/DeegreeQueryBuilder.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/DeegreeQueryBuilder.java
@@ -177,9 +177,11 @@ public class DeegreeQueryBuilder {
 		parser.removeErrorListeners();
 		parser.addErrorListener(new Cql2ErrorListener());
 		Cql2Parser.BooleanExpressionContext cql2 = parser.booleanExpression();
-		Set<QName> propertyNames = AppSchemas.collectProperyNames(featureTypeMetadata.getFeatureType().getSchema(),
-				featureTypeMetadata.getName());
-		Cql2FilterVisitor visitor = new Cql2FilterVisitor(lookupCrs(featuresRequest.getFilterCrs()), propertyNames);
+		Cql2FilterVisitor visitor = new Cql2FilterVisitor(lookupCrs(featuresRequest.getFilterCrs()),
+				featureTypeMetadata.getFilterProperties()
+					.stream()
+					.map(FilterProperty::getName)
+					.collect(Collectors.toSet()));
 		return (Operator) visitor.visit(cql2);
 	}
 

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/configuration/FilterProperty.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/configuration/FilterProperty.java
@@ -21,8 +21,6 @@
  */
 package org.deegree.services.oaf.workspace.configuration;
 
-import org.deegree.commons.tom.primitive.BaseType;
-
 import javax.xml.namespace.QName;
 
 /**
@@ -32,9 +30,9 @@ public class FilterProperty {
 
 	private QName name;
 
-	private BaseType type;
+	private FilterPropertyType type;
 
-	public FilterProperty(QName name, BaseType type) {
+	public FilterProperty(QName name, FilterPropertyType type) {
 		this.name = name;
 		this.type = type;
 	}
@@ -43,7 +41,7 @@ public class FilterProperty {
 		return name;
 	}
 
-	public BaseType getType() {
+	public FilterPropertyType getType() {
 		return type;
 	}
 

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/configuration/FilterPropertyType.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/configuration/FilterPropertyType.java
@@ -1,0 +1,27 @@
+package org.deegree.services.oaf.workspace.configuration;
+
+import org.deegree.commons.tom.primitive.BaseType;
+
+/**
+ * Enhances {@link org.deegree.commons.tom.primitive.BaseType} by GEOMETRY
+ *
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
+ */
+public enum FilterPropertyType {
+
+	STRING, BOOLEAN, DECIMAL, DOUBLE, INTEGER, DATE, DATE_TIME, TIME, GEOMETRY;
+
+	/**
+	 * @param baseType may be <code>null</code> (returns STRING)
+	 * @return FilterPropertyType derived from BaseType, fallback to STRING
+	 */
+	public static FilterPropertyType fromBaseType(BaseType baseType) {
+		try {
+			return FilterPropertyType.valueOf(baseType.name());
+		}
+		catch (IllegalArgumentException e) {
+			return STRING;
+		}
+	}
+
+}

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/configuration/FilterPropertyType.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/configuration/FilterPropertyType.java
@@ -1,5 +1,6 @@
 package org.deegree.services.oaf.workspace.configuration;
 
+import org.apache.xerces.xs.XSTypeDefinition;
 import org.deegree.commons.tom.primitive.BaseType;
 
 /**
@@ -22,6 +23,35 @@ public enum FilterPropertyType {
 		catch (IllegalArgumentException e) {
 			return STRING;
 		}
+	}
+
+	/**
+	 * @param typeDefinition may be <code>null</code> (returns null)
+	 * @return FilterPropertyType derived from XSTypeDefinition, <code>null</code>> of not
+	 * a mappable type
+	 */
+	public static FilterPropertyType fromXsdTypeDefinition(XSTypeDefinition typeDefinition) {
+		if (typeDefinition != null) {
+			String type = typeDefinition.getName();
+			switch (type) {
+				case "string":
+				case "anyURI":
+					return STRING;
+				case "boolean":
+					return BOOLEAN;
+				case "decimal":
+					return DECIMAL;
+				case "integer":
+					return INTEGER;
+				case "dateTime":
+					return DATE_TIME;
+				case "time":
+					return TIME;
+				case "date":
+					return DATE;
+			}
+		}
+		return null;
 	}
 
 }

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/cql2/Cql2ParserTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/cql2/Cql2ParserTest.java
@@ -27,8 +27,7 @@ import static org.junit.Assert.assertTrue;
 
 import javax.xml.namespace.QName;
 import java.util.Calendar;
-import java.util.Collections;
-import java.util.List;
+import java.util.Set;
 
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CharStream;
@@ -36,7 +35,6 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.deegree.commons.tom.TypedObjectNode;
 import org.deegree.commons.tom.datetime.Date;
 import org.deegree.commons.tom.datetime.DateTime;
-import org.deegree.commons.tom.primitive.BaseType;
 import org.deegree.commons.tom.primitive.PrimitiveValue;
 import org.deegree.cs.coordinatesystems.ICRS;
 import org.deegree.cs.exceptions.UnknownCRSException;
@@ -55,7 +53,6 @@ import org.deegree.geometry.multi.MultiPolygon;
 import org.deegree.geometry.primitive.LineString;
 import org.deegree.geometry.primitive.Point;
 import org.deegree.geometry.primitive.Polygon;
-import org.deegree.services.oaf.workspace.configuration.FilterProperty;
 import org.junit.Test;
 
 /**
@@ -72,7 +69,8 @@ public class Cql2ParserTest {
 
 		Expression param1 = ((Intersects) visit).getParam1();
 		assertTrue(param1 instanceof ValueReference);
-		assertEquals(((ValueReference) param1).getAsText(), "geometry");
+		assertEquals("geometry", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals("", ((ValueReference) param1).getAsQName().getNamespaceURI());
 
 		Geometry geometry = ((Intersects) visit).getGeometry();
 		assertTrue(geometry instanceof Point);
@@ -90,7 +88,8 @@ public class Cql2ParserTest {
 
 		Expression param1 = ((Intersects) visit).getParam1();
 		assertTrue(param1 instanceof ValueReference);
-		assertEquals(((ValueReference) param1).getAsText(), "geometry");
+		assertEquals("geometry", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals("", ((ValueReference) param1).getAsQName().getNamespaceURI());
 
 		Geometry geometry = ((Intersects) visit).getGeometry();
 		assertTrue(geometry instanceof LineString);
@@ -106,7 +105,8 @@ public class Cql2ParserTest {
 
 		Expression param1 = ((Intersects) visit).getParam1();
 		assertTrue(param1 instanceof ValueReference);
-		assertEquals(((ValueReference) param1).getAsText(), "geometry");
+		assertEquals("geometry", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals("", ((ValueReference) param1).getAsQName().getNamespaceURI());
 
 		Geometry geometry = ((Intersects) visit).getGeometry();
 		assertTrue(geometry instanceof Polygon);
@@ -123,7 +123,8 @@ public class Cql2ParserTest {
 
 		Expression param1 = ((Intersects) visit).getParam1();
 		assertTrue(param1 instanceof ValueReference);
-		assertEquals(((ValueReference) param1).getAsText(), "geometry");
+		assertEquals("geometry", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals("", ((ValueReference) param1).getAsQName().getNamespaceURI());
 
 		Geometry geometry = ((Intersects) visit).getGeometry();
 		assertTrue(geometry instanceof MultiPoint);
@@ -143,7 +144,8 @@ public class Cql2ParserTest {
 
 		Expression param1 = ((Intersects) visit).getParam1();
 		assertTrue(param1 instanceof ValueReference);
-		assertEquals(((ValueReference) param1).getAsText(), "geometry");
+		assertEquals("geometry", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals("", ((ValueReference) param1).getAsQName().getNamespaceURI());
 
 		Geometry geometry = ((Intersects) visit).getGeometry();
 		assertTrue(geometry instanceof MultiLineString);
@@ -161,7 +163,8 @@ public class Cql2ParserTest {
 
 		Expression param1 = ((Intersects) visit).getParam1();
 		assertTrue(param1 instanceof ValueReference);
-		assertEquals(((ValueReference) param1).getAsText(), "geometry");
+		assertEquals("geometry", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals("", ((ValueReference) param1).getAsQName().getNamespaceURI());
 
 		Geometry geometry = ((Intersects) visit).getGeometry();
 		assertTrue(geometry instanceof MultiPolygon);
@@ -181,7 +184,8 @@ public class Cql2ParserTest {
 
 		Expression param1 = ((Intersects) visit).getParam1();
 		assertTrue(param1 instanceof ValueReference);
-		assertEquals(((ValueReference) param1).getAsText(), "geometry");
+		assertEquals("geometry", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals("", ((ValueReference) param1).getAsQName().getNamespaceURI());
 
 		Geometry geometry = ((Intersects) visit).getGeometry();
 		assertTrue(geometry instanceof MultiGeometry);
@@ -200,7 +204,8 @@ public class Cql2ParserTest {
 
 		Expression param1 = ((Intersects) visit).getParam1();
 		assertTrue(param1 instanceof ValueReference);
-		assertEquals(((ValueReference) param1).getAsText(), "geometry");
+		assertEquals("geometry", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals("", ((ValueReference) param1).getAsQName().getNamespaceURI());
 
 		Geometry geometry = ((Intersects) visit).getGeometry();
 		assertTrue(geometry instanceof Envelope);
@@ -269,8 +274,7 @@ public class Cql2ParserTest {
 		Cql2Parser.BooleanExpressionContext cql2 = parser.booleanExpression();
 
 		ICRS filterCrs = CRSManager.lookup("urn:ogc:def:crs:OGC:1.3:CRS84");
-		List<FilterProperty> filterProperties = Collections
-			.singletonList(new FilterProperty(new QName("testDate"), BaseType.DATE));
+		Set<QName> filterProperties = Set.of(new QName("testDate"), new QName("geometry"));
 		Cql2FilterVisitor visitor = new Cql2FilterVisitor(filterCrs, filterProperties);
 		return visitor.visit(cql2);
 	}

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/workspace/DeegreeQueryBuilderTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/workspace/DeegreeQueryBuilderTest.java
@@ -22,7 +22,6 @@
 package org.deegree.services.oaf.workspace;
 
 import org.deegree.commons.tom.TypedObjectNode;
-import org.deegree.commons.tom.primitive.BaseType;
 import org.deegree.feature.persistence.query.Query;
 import org.deegree.filter.Filter;
 import org.deegree.filter.Operator;
@@ -41,6 +40,7 @@ import org.deegree.services.oaf.io.request.FeaturesRequest;
 import org.deegree.services.oaf.io.request.FeaturesRequestBuilder;
 import org.deegree.services.oaf.workspace.configuration.FeatureTypeMetadata;
 import org.deegree.services.oaf.workspace.configuration.FilterProperty;
+import org.deegree.services.oaf.workspace.configuration.FilterPropertyType;
 import org.deegree.services.oaf.workspace.configuration.OafDatasetConfiguration;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
@@ -219,7 +219,8 @@ public class DeegreeQueryBuilderTest {
 	@Test
 	public void test_CreateQueryWithSingleFilter() throws Exception {
 		DeegreeQueryBuilder deegreeQueryBuilder = new DeegreeQueryBuilder(mockOafConfiguration());
-		Map<FilterProperty, List<String>> filterParameters = createSingleFilterParams(BaseType.STRING, "value");
+		Map<FilterProperty, List<String>> filterParameters = createSingleFilterParams(FilterPropertyType.STRING,
+				"value");
 		FeaturesRequest featureRequest = new FeaturesRequestBuilder(COLLECTION_ID)
 			.withQueryableParameters(filterParameters)
 			.build();
@@ -233,7 +234,8 @@ public class DeegreeQueryBuilderTest {
 	@Test
 	public void test_CreateQueryWithSingleFilter_Wildcard() throws Exception {
 		DeegreeQueryBuilder deegreeQueryBuilder = new DeegreeQueryBuilder(mockOafConfiguration());
-		Map<FilterProperty, List<String>> filterParameters = createSingleFilterParams(BaseType.STRING, "value*");
+		Map<FilterProperty, List<String>> filterParameters = createSingleFilterParams(FilterPropertyType.STRING,
+				"value*");
 		FeaturesRequest featureRequest = new FeaturesRequestBuilder(COLLECTION_ID)
 			.withQueryableParameters(filterParameters)
 			.build();
@@ -247,7 +249,7 @@ public class DeegreeQueryBuilderTest {
 	@Test
 	public void test_CreateQueryWithSingleFilter_IntegerEqualTo() throws Exception {
 		DeegreeQueryBuilder deegreeQueryBuilder = new DeegreeQueryBuilder(mockOafConfiguration());
-		Map<FilterProperty, List<String>> filterParameters = createSingleFilterParams(BaseType.INTEGER, "10");
+		Map<FilterProperty, List<String>> filterParameters = createSingleFilterParams(FilterPropertyType.INTEGER, "10");
 		FeaturesRequest featureRequest = new FeaturesRequestBuilder(COLLECTION_ID)
 			.withQueryableParameters(filterParameters)
 			.build();
@@ -263,7 +265,8 @@ public class DeegreeQueryBuilderTest {
 	@Test
 	public void test_CreateQueryWithSingleFilter_DecimalGreaterThan() throws Exception {
 		DeegreeQueryBuilder deegreeQueryBuilder = new DeegreeQueryBuilder(mockOafConfiguration());
-		Map<FilterProperty, List<String>> filterParameters = createSingleFilterParams(BaseType.DECIMAL, ">9.56");
+		Map<FilterProperty, List<String>> filterParameters = createSingleFilterParams(FilterPropertyType.DECIMAL,
+				">9.56");
 		FeaturesRequest featureRequest = new FeaturesRequestBuilder(COLLECTION_ID)
 			.withQueryableParameters(filterParameters)
 			.build();
@@ -280,7 +283,8 @@ public class DeegreeQueryBuilderTest {
 	@Test
 	public void test_CreateQueryWithSingleFilter_DoubleLessThan() throws Exception {
 		DeegreeQueryBuilder deegreeQueryBuilder = new DeegreeQueryBuilder(mockOafConfiguration());
-		Map<FilterProperty, List<String>> filterParameters = createSingleFilterParams(BaseType.DOUBLE, "<5.89");
+		Map<FilterProperty, List<String>> filterParameters = createSingleFilterParams(FilterPropertyType.DOUBLE,
+				"<5.89");
 		FeaturesRequest featureRequest = new FeaturesRequestBuilder(COLLECTION_ID)
 			.withQueryableParameters(filterParameters)
 			.build();
@@ -297,7 +301,8 @@ public class DeegreeQueryBuilderTest {
 	@Test
 	public void test_CreateQueryWithSingleFilter_IntegerGreaterThanOrEqualTo() throws Exception {
 		DeegreeQueryBuilder deegreeQueryBuilder = new DeegreeQueryBuilder(mockOafConfiguration());
-		Map<FilterProperty, List<String>> filterParameters = createSingleFilterParams(BaseType.INTEGER, ">=10");
+		Map<FilterProperty, List<String>> filterParameters = createSingleFilterParams(FilterPropertyType.INTEGER,
+				">=10");
 		FeaturesRequest featureRequest = new FeaturesRequestBuilder(COLLECTION_ID)
 			.withQueryableParameters(filterParameters)
 			.build();
@@ -314,7 +319,8 @@ public class DeegreeQueryBuilderTest {
 	@Test
 	public void test_CreateQueryWithSingleFilter_IntegerLessThanOrEqualTo() throws Exception {
 		DeegreeQueryBuilder deegreeQueryBuilder = new DeegreeQueryBuilder(mockOafConfiguration());
-		Map<FilterProperty, List<String>> filterParameters = createSingleFilterParams(BaseType.INTEGER, "<=10");
+		Map<FilterProperty, List<String>> filterParameters = createSingleFilterParams(FilterPropertyType.INTEGER,
+				"<=10");
 		FeaturesRequest featureRequest = new FeaturesRequestBuilder(COLLECTION_ID)
 			.withQueryableParameters(filterParameters)
 			.build();
@@ -332,7 +338,7 @@ public class DeegreeQueryBuilderTest {
 	public void test_CreateQueryWithSingleFilterMultipleValues() throws Exception {
 		DeegreeQueryBuilder deegreeQueryBuilder = new DeegreeQueryBuilder(mockOafConfiguration());
 		Map<FilterProperty, List<String>> filterParameters = new MultivaluedHashMap<>();
-		filterParameters.put(new FilterProperty(new QName("http://deegree.org/oaf", "name"), BaseType.STRING),
+		filterParameters.put(new FilterProperty(new QName("http://deegree.org/oaf", "name"), FilterPropertyType.STRING),
 				Arrays.asList("value1", "value2"));
 		FeaturesRequest featureRequest = new FeaturesRequestBuilder(COLLECTION_ID)
 			.withQueryableParameters(filterParameters)
@@ -353,8 +359,9 @@ public class DeegreeQueryBuilderTest {
 	@Test
 	public void test_CreateQueryWithMultipleFilter() throws Exception {
 		DeegreeQueryBuilder deegreeQueryBuilder = new DeegreeQueryBuilder(mockOafConfiguration());
-		Map<FilterProperty, List<String>> filterParameters = createSingleFilterParams(BaseType.STRING, "value");
-		filterParameters.put(new FilterProperty(new QName("http://deegree.org/oaf", "age"), BaseType.INTEGER),
+		Map<FilterProperty, List<String>> filterParameters = createSingleFilterParams(FilterPropertyType.STRING,
+				"value");
+		filterParameters.put(new FilterProperty(new QName("http://deegree.org/oaf", "age"), FilterPropertyType.INTEGER),
 				Collections.singletonList("15"));
 		FeaturesRequest featureRequest = new FeaturesRequestBuilder(COLLECTION_ID)
 			.withQueryableParameters(filterParameters)
@@ -372,7 +379,7 @@ public class DeegreeQueryBuilderTest {
 		assertThat(second, is(CoreMatchers.instanceOf(PropertyIsEqualTo.class)));
 	}
 
-	private Map<FilterProperty, List<String>> createSingleFilterParams(BaseType type, String value) {
+	private Map<FilterProperty, List<String>> createSingleFilterParams(FilterPropertyType type, String value) {
 		Map<FilterProperty, List<String>> filterParameters = new MultivaluedHashMap<>();
 		QName name = new QName("http://deegree.org/oaf", "name");
 		FilterProperty filterProperty = new FilterProperty(name, type);


### PR DESCRIPTION
This PR extends the automated retrieval of supported queryables to also cover basic complex mappings at the top level.

**ATTENTION**: It is based on PR #163, which needs to be merged first!