### PR TITLE
Post release - bumped docker to v1.3.9

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -25,4 +25,4 @@ jobs:
           context: ./docker/1.3
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: deegree/deegree-ogcapi:1.3,deegree/deegree-ogcapi:1.3.8,deegree/deegree-ogcapi:latest
+          tags: deegree/deegree-ogcapi:1.3,deegree/deegree-ogcapi:1.3.9,deegree/deegree-ogcapi:latest

--- a/docker/1.3/Dockerfile
+++ b/docker/1.3/Dockerfile
@@ -15,7 +15,7 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
 LABEL maintainer="deegree TMC <tmc@deegree.org>"
 
 # set deegree OAF version
-ENV DEEGREE_OAF_VERSION=1.3.8
+ENV DEEGREE_OAF_VERSION=1.3.9
 
 # tomcat port
 EXPOSE 8080


### PR DESCRIPTION
This PR upgrades github action and dockerfile to v1.3.9