### PR TITLE
Upgrading Jenkinsfile build pipeline to JDK 17

### DIFF
--- a/jenkinsfiles/build/Jenkinsfile
+++ b/jenkinsfiles/build/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
   }
   tools {
     maven 'maven-3.9'
-    jdk 'adoptopenjdk-jdk11'
+    jdk 'adoptopenjdk-jdk17'
     git 'git-default'
   }
   environment {


### PR DESCRIPTION
This PR upgrades the Jenkinsfile build pipeline from JDK 11 to JDK 17.
This PR is seperated from PR #174 since any change on the pipeline must come from a PR in the same repo.
Therefore this PR needs to be merged before #174!