### PR TITLE
Added new step to ghaction to push images for release line 2.0

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -13,8 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        dialect: [ "oracle", "mssql", "postgres" ]
-        version: [ "1.3.9" ]
+        version: [ "1.3.9", "2.0.4" ]
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -32,12 +31,30 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: | 
-            deegree/deegree-ogcapi-${{ matrix.dialect }}:${{ matrix.version }}
-            deegree/deegree-ogcapi-${{ matrix.dialect }}:1.3
-            deegree/deegree-ogcapi-${{ matrix.dialect }}:latest
+            deegree/deegree-ogcapi:${{ matrix.version }}
+            deegree/deegree-ogcapi-postgres:${{ matrix.version }}
+            deegree/deegree-ogcapi:1.3
           build-args: |
             DEEGREE_VERSION=${{ matrix.version }}
-            DIALECT=${{ matrix.dialect }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
+            VCS_REF=${{ github.sha }}
+            VCS_URL=${{ github.repositoryUrl }}
+      - name: Build and push images for v2.0
+        if: startsWith(matrix.version, '2.0')
+        uses: docker/build-push-action@v6
+        with:
+          context: ./docker/2.0
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            deegree/deegree-ogcapi:${{ matrix.version }}
+            deegree/deegree-ogcapi-postgres:${{ matrix.version }}
+            deegree/deegree-ogcapi-mssql:${{ matrix.version }}
+            deegree/deegree-ogcapi-oracle:${{ matrix.version }}
+            deegree/deegree-ogcapi:2.0
+            deegree/deegree-ogcapi:latest
+          build-args: |
+            DEEGREE_VERSION=${{ matrix.version }}
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
             VCS_REF=${{ github.sha }}
             VCS_URL=${{ github.repositoryUrl }}

--- a/docker/2.0/Dockerfile
+++ b/docker/2.0/Dockerfile
@@ -1,13 +1,13 @@
 # This file is available under the following license:
 # under LGPL 2.1 (LICENSE.TXT) Copyright 2020 Torsten Friebe <tfr@users.sourceforge.net>
-FROM tomcat:9-jdk11
+FROM tomcat:10-jdk17-temurin-noble
 
 ENV LANG=en_US.UTF-8
 
 # add build info labels that can be set on build
 # see also https://github.com/opencontainers/image-spec/blob/master/annotations.md
-ARG DEEGREE_VERSION=1.3.9
-ARG DIALECT=postgres
+ARG DEEGREE_VERSION=2.0.4
+ARG DIALECT=all
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VCS_URL
@@ -17,11 +17,20 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
   org.opencontainers.image.version=$DEEGREE_VERSION
 LABEL maintainer="deegree TMC <tmc@deegree.org>"
 
+# health check (get dataset list)
+HEALTHCHECK \
+  --interval=60s \
+  --timeout=15s \
+  --start-period=2m \
+  --retries=3 \
+  CMD curl --fail "http://localhost:8080/deegree-ogcapi/datasets" || exit 1
+
 # tomcat port
 EXPOSE 8080
 
 # API key to use; if empty will not change API key
 ENV DEEGREE_API_KEY=
+ENV DEEGREE_WORKSPACE_ROOT=/root/.deegree
 
 # add deegree OGCAPI webapp
 RUN curl https://repo.deegree.org/content/repositories/public/org/deegree/deegree-ogcapi-webapp-${DIALECT}/${DEEGREE_VERSION}/deegree-ogcapi-webapp-${DIALECT}-${DEEGREE_VERSION}.war -o /tmp/deegree-ogcapi.war


### PR DESCRIPTION
This PR adds a new step to push images for deegree ogcapi 2.0 release line. The matrix build was changed to apply the breaking changes introduced with #194.

Only the image of the 1.3 line for postgres is updated: [deegree/deegree-ogcapi-postgres](https://hub.docker.com/r/deegree/deegree-ogcapi-postgres).
For the 2.0 line all images are updated, but all images contain all dialects, same as [deegree/deegree-ogcapi](https://hub.docker.com/r/deegree/deegree-ogcapi).