### PR TITLE
Derive links from X-Forwarded HTTP Headers

### DIFF
--- a/deegree-ogcapi-documentation/src/main/asciidoc/configuration.adoc
+++ b/deegree-ogcapi-documentation/src/main/asciidoc/configuration.adoc
@@ -487,12 +487,12 @@ and the specified header values
 ----
 
 deegree would report _https://www.mysecondgeoportal.com:8088/my-ogcapi/datasets_. The URL path is kept as in the request URL. Host, port, protocol and context path are replaced by the values from the header.
-If `X-Forwarded-Port`, `X-Forwarded-Proto` or `X-Forwarded-Prefix` are missing the values are taken from the request URL, deegree would report
+If `X-Forwarded-Port`, `X-Forwarded-Proto`, or `X-Forwarded-Prefix` are missing, the values are taken from the request URL, and deegree would report
 _http://www.mysecondgeoportal.com/deegree-ogcapi/datasets_.
-If `X-Forwarded-Prefix` is empty, the context path is removed from the URL and deegree would report
+If `X-Forwarded-Prefix` is empty, the context path is removed from the URL, and deegree would report
 _https://www.mysecondgeoportal.com:8088/datasets_.
 
-This behavior is useful when the deegree webservice can be requested via different URLs.
+This behavior is useful when the deegree ogcapi can be requested via different URLs.
 
 === Allow access to OpenAPI document from all origins
 

--- a/deegree-ogcapi-documentation/src/main/asciidoc/configuration.adoc
+++ b/deegree-ogcapi-documentation/src/main/asciidoc/configuration.adoc
@@ -469,6 +469,31 @@ The REST-API is enabled by default. To protect this interface from unauthorized 
 A detailed documentation of the REST-API interface and how access is configured is described in section "deegree REST interface"
 of the https://download.deegree.org/documentation/current/html/#anchor-configuration-restapi[deegree webservices handbook].
 
+=== Overwritting Links in reponses
+
+Links to other resources as well as the `self` and `alternate` links are derived from the requesting URL.
+
+The deegree ogcapi responses contains URLs that refer back or to other resources. By default, deegree derives these URLs from the incoming request. Sometimes it is required to override these URLs, for example when using deegree ogcapi behind a proxy or load balancer.
+
+The URLs are overwritten by the URL specified by the  `X-Forwarded-Proto`, `X-Forwarded-Host`, `X-Forwarded-Port` and `X-Forwarded-Prefix` header values. For example via a request to
+_http://realnameofdeegreemachine:8080/deegree-ogcapi/datasets_
+and the specified header values
+
+----
+* X-Forwarded-Host = www.mysecondgeoportal.com
+* X-Forwarded-Port = 8088
+* X-Forwarded-Proto = https
+* X-Forwarded-Prefix = my-ogcapi
+----
+
+deegree would report _https://www.mysecondgeoportal.com:8088/my-ogcapi/datasets_. The URL path is kept as in the request URL. Host, port, protocol and context path are replaced by the values from the header.
+If `X-Forwarded-Port`, `X-Forwarded-Proto` or `X-Forwarded-Prefix` are missing the values are taken from the request URL, deegree would report
+_http://www.mysecondgeoportal.com/deegree-ogcapi/datasets_.
+If `X-Forwarded-Prefix` is empty, the context path is removed from the URL and deegree would report
+_https://www.mysecondgeoportal.com:8088/datasets_.
+
+This behavior is useful when the deegree webservice can be requested via different URLs.
+
 === Allow access to OpenAPI document from all origins
 
 In case you want to avoid any issues when using the OpenAPI document from other locations due to CORS, you can enable allowing all origins specifically for accessing the OpenAPI document.

--- a/deegree-ogcapi-documentation/src/main/asciidoc/configuration.adoc
+++ b/deegree-ogcapi-documentation/src/main/asciidoc/configuration.adoc
@@ -471,8 +471,6 @@ of the https://download.deegree.org/documentation/current/html/#anchor-configura
 
 === Overwritting Links in reponses
 
-Links to other resources as well as the `self` and `alternate` links are derived from the requesting URL.
-
 The deegree ogcapi responses contains URLs that refer back or to other resources. By default, deegree derives these URLs from the incoming request. Sometimes it is required to override these URLs, for example when using deegree ogcapi behind a proxy or load balancer.
 
 The URLs are overwritten by the URL specified by the  `X-Forwarded-Proto`, `X-Forwarded-Host`, `X-Forwarded-Port` and `X-Forwarded-Prefix` header values. For example via a request to

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/link/LinkBuilder.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/link/LinkBuilder.java
@@ -96,6 +96,22 @@ public class LinkBuilder {
 
 	/**
 	 * @param datasetId id of the dataset, never <code>null</code>
+	 * @return link to this dataset, never <code>null</code>
+	 */
+	public String createDatasetLinkUrl(String datasetId) {
+		return createBaseUriBuilder(datasetId).toString();
+	}
+
+	/**
+	 * @param datasetId id of the dataset, never <code>null</code>
+	 * @return link to this dataset, never <code>null</code>
+	 */
+	public String createLicenseProviderLinkUrl(String datasetId) {
+		return createBaseUriBuilder(datasetId).path("license").path("provider").toString();
+	}
+
+	/**
+	 * @param datasetId id of the dataset, never <code>null</code>
 	 * @return list of links, never <code>null</code>
 	 */
 	public List<Link> createDatasetLinks(String datasetId) {

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/link/LinkBuilder.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/link/LinkBuilder.java
@@ -62,8 +62,6 @@ public class LinkBuilder {
 
 	private final UriInfo uriInfo;
 
-	private final HttpServletRequest request;
-
 	private final String requestedMediaType;
 
 	private static final Map<String, String> AVAILABLE_LINKS = Map.of(APPLICATION_JSON, "this document as JSON",
@@ -82,8 +80,7 @@ public class LinkBuilder {
 	}
 
 	public LinkBuilder(UriInfo uriInfo, HttpServletRequest request, String requestedMediaType) {
-		this.uriInfo = uriInfo;
-		this.request = request;
+		this.uriInfo = new UriInfoWithHeaderFromRequest(uriInfo, request);
 		this.requestedMediaType = requestedMediaType;
 	}
 
@@ -179,12 +176,12 @@ public class LinkBuilder {
 	}
 
 	public String createSchemaLink(String path) {
-		return overwriteWithHeaderValues(uriInfo.getBaseUriBuilder()).path("appschemas").path(path).toString();
+		return uriInfo.getBaseUriBuilder().path("appschemas").path(path).toString();
 	}
 
 	public List<Link> createFeaturesLinks(String datasetId, String collectionId, NextLink nextLink) {
 		List<Link> links = new ArrayList<>();
-		String selfUri = createSelfUriWithQueryParametersWExceptFormat();
+		String selfUri = createSelfUriWithQueryParametersExceptFormat();
 		addLinks(links, selfUri, AVAILABLE_GEO_LINKS);
 		if (nextLink != null) {
 			String nextUri = nextLink.createUri(uriInfo);
@@ -274,60 +271,20 @@ public class LinkBuilder {
 	}
 
 	private String getSelfUri() {
-		return overwriteWithHeaderValues(uriInfo.getBaseUriBuilder()).path(uriInfo.getPath()).toString();
+		return uriInfo.getRequestUriBuilder().toString();
 	}
 
-	private String createSelfUriWithQueryParametersWExceptFormat() {
-		return overwriteWithHeaderValues(uriInfo.getRequestUriBuilder()).replaceQueryParam("f", null).toString();
+	private String createSelfUriWithQueryParametersExceptFormat() {
+		return uriInfo.getRequestUriBuilder().replaceQueryParam("f", null).toString();
 	}
 
 	private UriBuilder createBaseUriBuilder(String datasetId) {
-		return overwriteWithHeaderValues(uriInfo.getBaseUriBuilder()).path("datasets").path(datasetId);
+		return uriInfo.getBaseUriBuilder().path("datasets").path(datasetId);
 	}
 
 	private Link createMetadataLink(MetadataUrl metadataUrl, String title) {
 		String type = metadataUrl.getFormat() != null ? metadataUrl.getFormat() : APPLICATION_XML;
 		return new Link(metadataUrl.getUrl(), DESCRIBEDBY.getRel(), type, title);
-	}
-
-	private UriBuilder overwriteWithHeaderValues(UriBuilder baseUriBuilder) {
-		if (request == null)
-			return baseUriBuilder;
-		String xForwardedProto = request.getHeader("X-Forwarded-Proto");
-		String xForwardedPort = request.getHeader("X-Forwarded-Port");
-		String xForwardedHost = request.getHeader("X-Forwarded-Host");
-
-		String proto = parseProtocol(xForwardedProto);
-		String host = parseHost(xForwardedHost);
-		String port = parsePort(xForwardedPort, xForwardedHost);
-		if (proto != null && !proto.isBlank())
-			baseUriBuilder.scheme(proto);
-		if (host != null && !host.isBlank())
-			baseUriBuilder.host(host);
-		if (port != null && !port.isBlank())
-			baseUriBuilder.port(Integer.parseInt(port));
-		return baseUriBuilder;
-	}
-
-	private String parseProtocol(String xForwardedProto) {
-		if (xForwardedProto != null && !xForwardedProto.isEmpty())
-			return xForwardedProto;
-		return null;
-	}
-
-	private String parseHost(String xForwardedHost) {
-		if (xForwardedHost != null && xForwardedHost.contains(":"))
-			return xForwardedHost.substring(0, xForwardedHost.indexOf(":"));
-		return xForwardedHost;
-	}
-
-	private String parsePort(String xForwardedPort, String xForwardedHost) {
-		if (xForwardedPort != null && !xForwardedPort.isEmpty())
-			return xForwardedPort;
-		else if (xForwardedHost != null && xForwardedHost.contains(":")
-				&& (xForwardedHost.lastIndexOf(":") + 1) < xForwardedHost.length())
-			return xForwardedHost.substring(xForwardedHost.lastIndexOf(":") + 1);
-		return null;
 	}
 
 }

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/link/LinkBuilder.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/link/LinkBuilder.java
@@ -48,6 +48,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
 import org.deegree.commons.ows.metadata.MetadataUrl;
@@ -60,6 +61,8 @@ import org.deegree.services.oaf.workspace.configuration.DatasetMetadata;
 public class LinkBuilder {
 
 	private final UriInfo uriInfo;
+
+	private final HttpServletRequest request;
 
 	private final String requestedMediaType;
 
@@ -74,12 +77,13 @@ public class LinkBuilder {
 			"this document as GML", APPLICATION_GML_SF0, "this document as GML", APPLICATION_GML_SF2,
 			"this document as GML");
 
-	public LinkBuilder(UriInfo uriInfo) {
-		this(uriInfo, null);
+	public LinkBuilder(UriInfo uriInfo, HttpServletRequest request) {
+		this(uriInfo, request, null);
 	}
 
-	public LinkBuilder(UriInfo uriInfo, String requestedMediaType) {
+	public LinkBuilder(UriInfo uriInfo, HttpServletRequest request, String requestedMediaType) {
 		this.uriInfo = uriInfo;
+		this.request = request;
 		this.requestedMediaType = requestedMediaType;
 	}
 
@@ -175,7 +179,7 @@ public class LinkBuilder {
 	}
 
 	public String createSchemaLink(String path) {
-		return uriInfo.getBaseUriBuilder().path("appschemas").path(path).toString();
+		return overwriteWithHeaderValues(uriInfo.getBaseUriBuilder()).path("appschemas").path(path).toString();
 	}
 
 	public List<Link> createFeaturesLinks(String datasetId, String collectionId, NextLink nextLink) {
@@ -270,20 +274,60 @@ public class LinkBuilder {
 	}
 
 	private String getSelfUri() {
-		return uriInfo.getBaseUriBuilder().path(uriInfo.getPath()).toString();
+		return overwriteWithHeaderValues(uriInfo.getBaseUriBuilder()).path(uriInfo.getPath()).toString();
 	}
 
 	private String createSelfUriWithQueryParametersWExceptFormat() {
-		return uriInfo.getRequestUriBuilder().replaceQueryParam("f", null).toString();
+		return overwriteWithHeaderValues(uriInfo.getRequestUriBuilder()).replaceQueryParam("f", null).toString();
 	}
 
 	private UriBuilder createBaseUriBuilder(String datasetId) {
-		return uriInfo.getBaseUriBuilder().path("datasets").path(datasetId);
+		return overwriteWithHeaderValues(uriInfo.getBaseUriBuilder()).path("datasets").path(datasetId);
 	}
 
 	private Link createMetadataLink(MetadataUrl metadataUrl, String title) {
 		String type = metadataUrl.getFormat() != null ? metadataUrl.getFormat() : APPLICATION_XML;
 		return new Link(metadataUrl.getUrl(), DESCRIBEDBY.getRel(), type, title);
+	}
+
+	private UriBuilder overwriteWithHeaderValues(UriBuilder baseUriBuilder) {
+		if (request == null)
+			return baseUriBuilder;
+		String xForwardedProto = request.getHeader("X-Forwarded-Proto");
+		String xForwardedPort = request.getHeader("X-Forwarded-Port");
+		String xForwardedHost = request.getHeader("X-Forwarded-Host");
+
+		String proto = parseProtocol(xForwardedProto);
+		String host = parseHost(xForwardedHost);
+		String port = parsePort(xForwardedPort, xForwardedHost);
+		if (proto != null && !proto.isBlank())
+			baseUriBuilder.scheme(proto);
+		if (host != null && !host.isBlank())
+			baseUriBuilder.host(host);
+		if (port != null && !port.isBlank())
+			baseUriBuilder.port(Integer.parseInt(port));
+		return baseUriBuilder;
+	}
+
+	private String parseProtocol(String xForwardedProto) {
+		if (xForwardedProto != null && !xForwardedProto.isEmpty())
+			return xForwardedProto;
+		return null;
+	}
+
+	private String parseHost(String xForwardedHost) {
+		if (xForwardedHost != null && xForwardedHost.contains(":"))
+			return xForwardedHost.substring(0, xForwardedHost.indexOf(":"));
+		return xForwardedHost;
+	}
+
+	private String parsePort(String xForwardedPort, String xForwardedHost) {
+		if (xForwardedPort != null && !xForwardedPort.isEmpty())
+			return xForwardedPort;
+		else if (xForwardedHost != null && xForwardedHost.contains(":")
+				&& (xForwardedHost.lastIndexOf(":") + 1) < xForwardedHost.length())
+			return xForwardedHost.substring(xForwardedHost.lastIndexOf(":") + 1);
+		return null;
 	}
 
 }

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/link/UriInfoWithHeaderFromRequest.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/link/UriInfoWithHeaderFromRequest.java
@@ -1,0 +1,234 @@
+/*-
+ * #%L
+ * deegree-ogcapi-features - OGC API Features (OAF) implementation - Querying and modifying of geospatial data objects
+ * %%
+ * Copyright (C) 2019 - 2026 lat/lon GmbH, info@lat-lon.de, www.lat-lon.de
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package org.deegree.services.oaf.link;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.PathSegment;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriInfo;
+
+/**
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
+ */
+public class UriInfoWithHeaderFromRequest implements UriInfo {
+
+	private final UriInfo uriInfo;
+
+	private final String contextPathFromServletContextWithoutLeadingSlash;
+
+	private final String proto;
+
+	private final String host;
+
+	private final String port;
+
+	private final String pathPrefix;
+
+	public UriInfoWithHeaderFromRequest(UriInfo uriInfo, HttpServletRequest request) {
+		this.uriInfo = uriInfo;
+		this.contextPathFromServletContextWithoutLeadingSlash = parseContextPathFromServletContextWithoutLeadingSlash(
+				request);
+
+		String xForwardedProto = request != null ? request.getHeader("X-Forwarded-Proto") : null;
+		String xForwardedPort = request != null ? request.getHeader("X-Forwarded-Port") : null;
+		String xForwardedHost = request != null ? request.getHeader("X-Forwarded-Host") : null;
+		String xForwardedPrefix = request != null ? request.getHeader("X-Forwarded-Prefix") : null;
+
+		this.proto = parseProtocol(xForwardedProto);
+		this.host = parseHost(xForwardedHost);
+		this.port = parsePort(xForwardedPort, xForwardedHost);
+		this.pathPrefix = parsePrefix(xForwardedPrefix, request != null ? request.getContextPath() : null);
+	}
+
+	@Override
+	public String getPath() {
+		return "/" + overwritePathWithContextPathFromHeader(uriInfo.getPathSegments()).stream()
+			.map(PathSegment::getPath)
+			.collect(Collectors.joining("/"));
+	}
+
+	@Override
+	public String getPath(boolean b) {
+		return "/" + overwritePathWithContextPathFromHeader(uriInfo.getPathSegments(b)).stream()
+			.map(PathSegment::getPath)
+			.collect(Collectors.joining("/"));
+	}
+
+	@Override
+	public List<PathSegment> getPathSegments() {
+		return overwritePathWithContextPathFromHeader(uriInfo.getPathSegments());
+	}
+
+	@Override
+	public List<PathSegment> getPathSegments(boolean b) {
+		return overwritePathWithContextPathFromHeader(uriInfo.getPathSegments(b));
+	}
+
+	@Override
+	public URI getRequestUri() {
+		return uriInfo.getRequestUri();
+	}
+
+	@Override
+	public UriBuilder getRequestUriBuilder() {
+		UriBuilder requestUriBuilder = overwriteWithHeaderValues(uriInfo.getRequestUriBuilder());
+		requestUriBuilder.replacePath(pathPrefix).path(getPath());
+		return requestUriBuilder;
+	}
+
+	@Override
+	public URI getAbsolutePath() {
+		return uriInfo.getAbsolutePath();
+	}
+
+	@Override
+	public UriBuilder getAbsolutePathBuilder() {
+		return uriInfo.getAbsolutePathBuilder();
+	}
+
+	@Override
+	public URI getBaseUri() {
+		return uriInfo.getBaseUri();
+	}
+
+	@Override
+	public UriBuilder getBaseUriBuilder() {
+		UriBuilder baseUriBuilder = overwriteWithHeaderValues(uriInfo.getBaseUriBuilder());
+		baseUriBuilder.replacePath(pathPrefix);
+		return baseUriBuilder;
+	}
+
+	@Override
+	public MultivaluedMap<String, String> getPathParameters() {
+		return uriInfo.getPathParameters();
+	}
+
+	@Override
+	public MultivaluedMap<String, String> getPathParameters(boolean b) {
+		return uriInfo.getPathParameters(b);
+	}
+
+	@Override
+	public MultivaluedMap<String, String> getQueryParameters() {
+		return uriInfo.getQueryParameters();
+	}
+
+	@Override
+	public MultivaluedMap<String, String> getQueryParameters(boolean b) {
+		return uriInfo.getQueryParameters(b);
+	}
+
+	@Override
+	public List<String> getMatchedURIs() {
+		return uriInfo.getMatchedURIs();
+	}
+
+	@Override
+	public List<String> getMatchedURIs(boolean b) {
+		return uriInfo.getMatchedURIs(b);
+	}
+
+	@Override
+	public List<Object> getMatchedResources() {
+		return uriInfo.getMatchedResources();
+	}
+
+	@Override
+	public URI resolve(URI uri) {
+		return uriInfo.resolve(uri);
+	}
+
+	@Override
+	public URI relativize(URI uri) {
+		return uriInfo.relativize(uri);
+	}
+
+	private UriBuilder overwriteWithHeaderValues(UriBuilder baseUriBuilder) {
+		if (proto != null && !proto.isBlank())
+			baseUriBuilder.scheme(proto);
+		if (host != null && !host.isBlank())
+			baseUriBuilder.host(host);
+		if (port != null && !port.isBlank())
+			baseUriBuilder.port(Integer.parseInt(port));
+
+		return baseUriBuilder;
+	}
+
+	private List<PathSegment> overwritePathWithContextPathFromHeader(List<PathSegment> pathSegments) {
+		if (pathPrefix == null)
+			return pathSegments;
+		if (pathPrefix.isEmpty() && !pathSegments.isEmpty()
+				&& pathSegments.get(0).getPath().equals(contextPathFromServletContextWithoutLeadingSlash))
+			return pathSegments.stream().skip(1).toList();
+		if (!pathPrefix.isEmpty()) {
+			if (!pathSegments.isEmpty()
+					&& pathSegments.get(0).getPath().equals(contextPathFromServletContextWithoutLeadingSlash)) {
+				return pathSegments.stream().skip(1).collect(Collectors.toList());
+			}
+			else {
+				return new ArrayList<>(pathSegments);
+			}
+		}
+		return pathSegments;
+	}
+
+	private static String parseContextPathFromServletContextWithoutLeadingSlash(HttpServletRequest request) {
+		if (request == null || request.getContextPath() == null)
+			return null;
+		return request.getContextPath().startsWith("/") ? request.getContextPath().substring(1)
+				: request.getContextPath();
+	}
+
+	private String parseProtocol(String xForwardedProto) {
+		if (xForwardedProto != null && !xForwardedProto.isEmpty())
+			return xForwardedProto;
+		return null;
+	}
+
+	private String parseHost(String xForwardedHost) {
+		if (xForwardedHost != null && xForwardedHost.contains(":"))
+			return xForwardedHost.substring(0, xForwardedHost.indexOf(":"));
+		return xForwardedHost;
+	}
+
+	private String parsePort(String xForwardedPort, String xForwardedHost) {
+		if (xForwardedPort != null && !xForwardedPort.isEmpty())
+			return xForwardedPort;
+		else if (xForwardedHost != null && xForwardedHost.contains(":")
+				&& (xForwardedHost.lastIndexOf(":") + 1) < xForwardedHost.length())
+			return xForwardedHost.substring(xForwardedHost.lastIndexOf(":") + 1);
+		return null;
+	}
+
+	private String parsePrefix(String xForwardedPrefix, String contextPath) {
+		if (xForwardedPrefix == null)
+			return contextPath;
+		return xForwardedPrefix;
+	}
+
+}

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/openapi/OafOpenApiFilter.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/openapi/OafOpenApiFilter.java
@@ -26,6 +26,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
@@ -34,6 +35,7 @@ import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.servers.Server;
+import jakarta.inject.Inject;
 import org.apache.xerces.xs.XSComplexTypeDefinition;
 import org.apache.xerces.xs.XSElementDeclaration;
 import org.apache.xerces.xs.XSModelGroup;
@@ -52,6 +54,7 @@ import org.deegree.feature.types.property.GeometryPropertyType;
 import org.deegree.feature.types.property.SimplePropertyType;
 import org.deegree.gml.GMLVersion;
 import org.deegree.services.oaf.exceptions.UnknownDatasetId;
+import org.deegree.services.oaf.link.LinkBuilder;
 import org.deegree.services.oaf.workspace.DeegreeWorkspaceInitializer;
 import org.deegree.services.oaf.workspace.configuration.FeatureTypeMetadata;
 import org.deegree.cql2.FilterProperty;
@@ -59,9 +62,6 @@ import org.deegree.cql2.FilterPropertyType;
 import org.deegree.services.oaf.workspace.configuration.OafDatasetConfiguration;
 import org.deegree.services.oaf.workspace.configuration.OafDatasets;
 import org.slf4j.Logger;
-
-import jakarta.inject.Inject;
-import jakarta.ws.rs.core.UriInfo;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -121,7 +121,7 @@ public class OafOpenApiFilter extends AbstractSpecFilter {
 
 	public static final String GEOMETRY_PROPERTY_NAME = "geometry";
 
-	private final UriInfo uriInfo;
+	private final LinkBuilder linkBuilder;
 
 	private final String datasetId;
 
@@ -130,9 +130,9 @@ public class OafOpenApiFilter extends AbstractSpecFilter {
 	@Inject
 	private DeegreeWorkspaceInitializer deegreeWorkspaceInitializer;
 
-	public OafOpenApiFilter(UriInfo uriInfo, String datasetId, DeegreeWorkspaceInitializer deegreeWorkspaceInitializer)
-			throws UnknownDatasetId {
-		this.uriInfo = uriInfo;
+	public OafOpenApiFilter(LinkBuilder linkBuilder, String datasetId,
+			DeegreeWorkspaceInitializer deegreeWorkspaceInitializer) throws UnknownDatasetId {
+		this.linkBuilder = linkBuilder;
 		this.datasetId = datasetId;
 		OafDatasets oafDatasets = deegreeWorkspaceInitializer.getOafDatasets();
 		this.datasetConfiguration = oafDatasets.getDataset(datasetId);
@@ -141,16 +141,22 @@ public class OafOpenApiFilter extends AbstractSpecFilter {
 	@Override
 	public Optional<OpenAPI> filterOpenAPI(OpenAPI openAPI, Map<String, List<String>> params,
 			Map<String, String> cookies, Map<String, List<String>> headers) {
+		filterLicense(openAPI.getInfo().getLicense());
 		filterServers(openAPI);
 		filterPaths(openAPI);
 		return super.filterOpenAPI(openAPI, params, cookies, headers);
+	}
+
+	private void filterLicense(License license) {
+		if (license != null)
+			license.setUrl(linkBuilder.createLicenseProviderLinkUrl(datasetId));
 	}
 
 	private void filterServers(OpenAPI openAPI) {
 		if (openAPI.getServers() == null || openAPI.getServers().isEmpty())
 			openAPI.addServersItem(new Server());
 		Server server = openAPI.getServers().get(0);
-		String absolutePathToOpenApi = uriInfo.getBaseUriBuilder().path("datasets").path(datasetId).toString();
+		String absolutePathToOpenApi = linkBuilder.createDatasetLinkUrl(datasetId);
 		server.setUrl(absolutePathToOpenApi);
 	}
 
@@ -289,12 +295,12 @@ public class OafOpenApiFilter extends AbstractSpecFilter {
 		Schema id = new Schema().name("id").type("string").example("ID_1");
 		schema.addProperties("type", type);
 		schema.addProperties("id", id);
-		addGeoemtrySchema(featureType, schema);
+		addGeometrySchema(featureType, schema);
 		addPropertiesSchema(featureType, schema);
 		return schema;
 	}
 
-	private void addGeoemtrySchema(FeatureType featureType, Schema<Object> schema) {
+	private void addGeometrySchema(FeatureType featureType, Schema<Object> schema) {
 		if (featureType.getDefaultGeometryPropertyDeclaration() != null) {
 			Schema geometryPropertySchema = createGeometryPropertySchema();
 			schema.addProperties(GEOMETRY_PROPERTY_NAME, geometryPropertySchema);

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/openapi/OpenApiCreator.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/openapi/OpenApiCreator.java
@@ -30,8 +30,9 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
-import io.swagger.v3.oas.models.servers.Server;
+import jakarta.servlet.http.HttpServletRequest;
 import org.deegree.services.oaf.exceptions.UnknownDatasetId;
+import org.deegree.services.oaf.link.LinkBuilder;
 import org.deegree.services.oaf.workspace.DeegreeWorkspaceInitializer;
 import org.deegree.services.oaf.workspace.configuration.DatasetMetadata;
 import org.deegree.services.oaf.workspace.configuration.OafDatasetConfiguration;
@@ -44,7 +45,6 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.UriInfo;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -74,7 +74,8 @@ public class OpenApiCreator {
 	@Inject
 	private DeegreeWorkspaceInitializer deegreeWorkspaceInitializer;
 
-	public OpenAPI createOpenApi(HttpHeaders headers, UriInfo uriInfo, String datasetId) throws Exception {
+	public OpenAPI createOpenApi(HttpHeaders headers, UriInfo uriInfo, HttpServletRequest servletRequest,
+			String datasetId) throws Exception {
 		OpenAPI oas = createOpenApiDocument(datasetId);
 		SwaggerConfiguration oasConfig = createSwaggerConfiguration(oas);
 
@@ -94,7 +95,8 @@ public class OpenApiCreator {
 		if (oas2 != null && ctx.getOpenApiConfiguration() != null
 				&& ctx.getOpenApiConfiguration().getFilterClass() != null) {
 			try {
-				OafOpenApiFilter filter = new OafOpenApiFilter(uriInfo, datasetId, deegreeWorkspaceInitializer);
+				OafOpenApiFilter filter = new OafOpenApiFilter(new LinkBuilder(uriInfo, servletRequest), datasetId,
+						deegreeWorkspaceInitializer);
 				SpecFilter f = new SpecFilter();
 				oas2 = f.filter(oas2, filter, getQueryParams(this.uriInfo.getQueryParameters()), getCookies(headers),
 						getHeaders(headers));

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/Appschema.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/Appschema.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -73,9 +74,10 @@ public class Appschema {
 	@Operation(operationId = "appschema", summary = "retrieve GML application schema of collection {collectionId}",
 			description = "Retrieves the GML application schema of the collection with the id {collectionId}. The GML application schema describes the structure of the XML representation of the features.")
 	@Tag(name = "Schema")
-	public Response appschema(@Context UriInfo uriInfo, @PathParam("datasetId") String datasetId,
-			@PathParam("collectionId") String collectionId) throws UnknownDatasetId, UnknownCollectionId {
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo, APPLICATION_XML);
+	public Response appschema(@Context UriInfo uriInfo, @Context HttpServletRequest request,
+			@PathParam("datasetId") String datasetId, @PathParam("collectionId") String collectionId)
+			throws UnknownDatasetId, UnknownCollectionId {
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo, request, APPLICATION_XML);
 		OafDatasets oafDatasets = deegreeWorkspaceInitializer.getOafDatasets();
 		OafDatasetConfiguration dataset = oafDatasets.getDataset(datasetId);
 		FeatureTypeMetadata featureTypeMetadata = dataset.getFeatureTypeMetadata(collectionId);

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/Datasets.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/Datasets.java
@@ -65,7 +65,7 @@ public class Datasets {
 	@GET
 	@Produces({ APPLICATION_JSON })
 	@Operation(hidden = true)
-	public Response datasetsJson(@Context UriInfo uriInfo, HttpServletRequest servletRequest,
+	public Response datasetsJson(@Context UriInfo uriInfo, @Context HttpServletRequest servletRequest,
 			@Parameter(description = "The request output format.", style = ParameterStyle.FORM,
 					schema = @Schema(allowableValues = { "json", "html", "xml" })) @QueryParam("f") String format)
 			throws InvalidParameterValue {
@@ -76,7 +76,7 @@ public class Datasets {
 	@GET
 	@Produces({ TEXT_HTML })
 	@Operation(hidden = true)
-	public Response datasetsHtml(@Context UriInfo uriInfo, HttpServletRequest servletRequest,
+	public Response datasetsHtml(@Context UriInfo uriInfo, @Context HttpServletRequest servletRequest,
 			@Parameter(description = "The request output format.", style = ParameterStyle.FORM,
 					schema = @Schema(allowableValues = { "json", "html", "xml" })) @QueryParam("f") String format)
 			throws InvalidParameterValue {

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/Datasets.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/Datasets.java
@@ -35,6 +35,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterStyle;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -64,30 +65,31 @@ public class Datasets {
 	@GET
 	@Produces({ APPLICATION_JSON })
 	@Operation(hidden = true)
-	public Response datasetsJson(@Context UriInfo uriInfo,
+	public Response datasetsJson(@Context UriInfo uriInfo, HttpServletRequest servletRequest,
 			@Parameter(description = "The request output format.", style = ParameterStyle.FORM,
 					schema = @Schema(allowableValues = { "json", "html", "xml" })) @QueryParam("f") String format)
 			throws InvalidParameterValue {
 		RequestedMediaType requestedMediaType = new RequestedMediaType(format, JSON, APPLICATION_JSON);
-		return datasets(uriInfo, requestedMediaType);
+		return datasets(uriInfo, servletRequest, requestedMediaType);
 	}
 
 	@GET
 	@Produces({ TEXT_HTML })
 	@Operation(hidden = true)
-	public Response datasetsHtml(@Context UriInfo uriInfo,
+	public Response datasetsHtml(@Context UriInfo uriInfo, HttpServletRequest servletRequest,
 			@Parameter(description = "The request output format.", style = ParameterStyle.FORM,
 					schema = @Schema(allowableValues = { "json", "html", "xml" })) @QueryParam("f") String format)
 			throws InvalidParameterValue {
 		RequestedMediaType requestedMediaType = new RequestedMediaType(format, HTML, TEXT_HTML);
-		return datasets(uriInfo, requestedMediaType);
+		return datasets(uriInfo, servletRequest, requestedMediaType);
 	}
 
-	private Response datasets(UriInfo uriInfo, RequestedMediaType requestedMediaType) throws InvalidParameterValue {
+	private Response datasets(UriInfo uriInfo, HttpServletRequest servletRequest, RequestedMediaType requestedMediaType)
+			throws InvalidParameterValue {
 		if (HTML.equals(requestedMediaType.getRequestFormat())) {
 			return Response.ok(getClass().getResourceAsStream("/datasets.html"), TEXT_HTML).build();
 		}
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo, requestedMediaType.getSelfMediaType());
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo, servletRequest, requestedMediaType.getSelfMediaType());
 		List<Link> links = linkBuilder.createDatasetsLinks();
 		List<Dataset> datasets = new ArrayList<>();
 

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/Feature.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/Feature.java
@@ -37,6 +37,7 @@ import io.swagger.v3.oas.annotations.enums.ParameterStyle;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.Path;
@@ -79,8 +80,9 @@ public class Feature {
 	@Operation(operationId = "feature", summary = "retrieves feature of collection {collectionId}",
 			description = "Retrieves one single feature of the collection with the id {collectionId}")
 	@Tag(name = "Data")
-	public Response featureJson(@Context UriInfo uriInfo, @PathParam("datasetId") String datasetId,
-			@PathParam("collectionId") String collectionId, @PathParam("featureId") String featureId,
+	public Response featureJson(@Context UriInfo uriInfo, @Context HttpServletRequest servletRequest,
+			@PathParam("datasetId") String datasetId, @PathParam("collectionId") String collectionId,
+			@PathParam("featureId") String featureId,
 			@Parameter(description = "The coordinate reference system of the response geometries.",
 					style = ParameterStyle.FORM) @QueryParam("crs") String crs,
 			@Parameter(description = "The request output format.", style = ParameterStyle.FORM,
@@ -88,15 +90,16 @@ public class Feature {
 			throws UnknownCollectionId, InternalQueryException, InvalidParameterValue, UnknownDatasetId,
 			UnknownFeatureId {
 		RequestedMediaType requestedMediaType = new RequestedMediaType(format, JSON, APPLICATION_GEOJSON);
-		return feature(uriInfo, datasetId, collectionId, featureId, crs, requestedMediaType);
+		return feature(uriInfo, servletRequest, datasetId, collectionId, featureId, crs, requestedMediaType);
 	}
 
 	@GET
 	@Produces({ APPLICATION_GML, APPLICATION_GML_32, APPLICATION_GML_SF0, APPLICATION_GML_SF2 })
 	@Operation(hidden = true)
 	public Response featureGml(@Context Request request, @Context UriInfo uriInfo,
-			@HeaderParam("Accept") String acceptHeader, @PathParam("datasetId") String datasetId,
-			@PathParam("collectionId") String collectionId, @PathParam("featureId") String featureId,
+			@Context HttpServletRequest servletRequest, @HeaderParam("Accept") String acceptHeader,
+			@PathParam("datasetId") String datasetId, @PathParam("collectionId") String collectionId,
+			@PathParam("featureId") String featureId,
 			@Parameter(description = "The coordinate reference system of the response geometries.",
 					style = ParameterStyle.FORM) @QueryParam("crs") String crs,
 			@Parameter(description = "The request output format.", style = ParameterStyle.FORM,
@@ -104,14 +107,15 @@ public class Feature {
 			throws UnknownCollectionId, InternalQueryException, InvalidParameterValue, UnknownDatasetId,
 			UnknownFeatureId {
 		RequestedMediaType requestedMediaType = new RequestedMediaType(format, XML, acceptHeader, APPLICATION_GML);
-		return feature(uriInfo, datasetId, collectionId, featureId, crs, requestedMediaType);
+		return feature(uriInfo, servletRequest, datasetId, collectionId, featureId, crs, requestedMediaType);
 	}
 
 	@GET
 	@Produces({ TEXT_HTML })
 	@Operation(hidden = true)
-	public Response featureHtml(@Context UriInfo uriInfo, @PathParam("datasetId") String datasetId,
-			@PathParam("collectionId") String collectionId, @PathParam("featureId") String featureId,
+	public Response featureHtml(@Context UriInfo uriInfo, @Context HttpServletRequest servletRequest,
+			@PathParam("datasetId") String datasetId, @PathParam("collectionId") String collectionId,
+			@PathParam("featureId") String featureId,
 			@Parameter(description = "The coordinate reference system of the response geometries.",
 					style = ParameterStyle.FORM) @QueryParam("crs") String crs,
 			@Parameter(description = "The request output format.", style = ParameterStyle.FORM,
@@ -119,13 +123,14 @@ public class Feature {
 			throws InvalidParameterValue, UnknownDatasetId, UnknownCollectionId, InternalQueryException,
 			UnknownFeatureId {
 		RequestedMediaType requestedMediaType = new RequestedMediaType(format, HTML, TEXT_HTML);
-		return feature(uriInfo, datasetId, collectionId, featureId, crs, requestedMediaType);
+		return feature(uriInfo, servletRequest, datasetId, collectionId, featureId, crs, requestedMediaType);
 	}
 
 	@GET
 	@Operation(hidden = true)
-	public Response featureOther(@Context UriInfo uriInfo, @PathParam("datasetId") String datasetId,
-			@PathParam("collectionId") String collectionId, @PathParam("featureId") String featureId,
+	public Response featureOther(@Context UriInfo uriInfo, @Context HttpServletRequest servletRequest,
+			@PathParam("datasetId") String datasetId, @PathParam("collectionId") String collectionId,
+			@PathParam("featureId") String featureId,
 			@Parameter(description = "The coordinate reference system of the response geometries.",
 					style = ParameterStyle.FORM) @QueryParam("crs") String crs,
 			@Parameter(description = "The request output format.", style = ParameterStyle.FORM,
@@ -133,19 +138,19 @@ public class Feature {
 			throws InvalidParameterValue, UnknownDatasetId, UnknownCollectionId, InternalQueryException,
 			UnknownFeatureId {
 		RequestedMediaType requestedMediaType = new RequestedMediaType(format, HTML, TEXT_HTML);
-		return feature(uriInfo, datasetId, collectionId, featureId, crs, requestedMediaType);
+		return feature(uriInfo, servletRequest, datasetId, collectionId, featureId, crs, requestedMediaType);
 	}
 
-	private Response feature(UriInfo uriInfo, String datasetId, String collectionId, String featureId, String crs,
-			RequestedMediaType requestedMediaType) throws UnknownCollectionId, InternalQueryException,
-			InvalidParameterValue, UnknownDatasetId, UnknownFeatureId {
+	private Response feature(UriInfo uriInfo, HttpServletRequest servletRequest, String datasetId, String collectionId,
+			String featureId, String crs, RequestedMediaType requestedMediaType) throws UnknownCollectionId,
+			InternalQueryException, InvalidParameterValue, UnknownDatasetId, UnknownFeatureId {
 		OafDatasetConfiguration oafConfiguration = deegreeWorkspaceInitializer.getOafDatasets().getDataset(datasetId);
 		oafConfiguration.checkCollection(collectionId);
 		if (HTML.equals(requestedMediaType.getRequestFormat())) {
 			return Response.ok(getClass().getResourceAsStream("/feature.html"), TEXT_HTML).build();
 		}
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo, requestedMediaType.getSelfMediaType());
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo, servletRequest, requestedMediaType.getSelfMediaType());
 		FeatureResponse featureResponse = dataAccess.retrieveFeature(oafConfiguration, collectionId, featureId, crs,
 				linkBuilder);
 		if (XML.equals(requestedMediaType.getRequestFormat())) {

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/FeatureCollection.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/FeatureCollection.java
@@ -40,6 +40,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -86,9 +87,10 @@ public class FeatureCollection {
 			@PathParam("collectionId") String collectionId,
 			@Parameter(description = "The request output format.", style = ParameterStyle.FORM,
 					schema = @Schema(allowableValues = { "json", "html", "xml" })) @QueryParam("f") String format,
-			@Context UriInfo uriInfo) throws UnknownCollectionId, UnknownDatasetId, InvalidParameterValue {
+			@Context UriInfo uriInfo, @Context HttpServletRequest servletRequest)
+			throws UnknownCollectionId, UnknownDatasetId, InvalidParameterValue {
 		RequestedMediaType requestedMediaType = new RequestedMediaType(format, JSON, APPLICATION_JSON);
-		return collection(datasetId, collectionId, uriInfo, requestedMediaType);
+		return collection(datasetId, collectionId, uriInfo, servletRequest, requestedMediaType);
 	}
 
 	@GET
@@ -98,9 +100,10 @@ public class FeatureCollection {
 			@PathParam("collectionId") String collectionId,
 			@Parameter(description = "The request output format.", style = ParameterStyle.FORM,
 					schema = @Schema(allowableValues = { "json", "html", "xml" })) @QueryParam("f") String format,
-			@Context UriInfo uriInfo) throws UnknownCollectionId, UnknownDatasetId, InvalidParameterValue {
+			@Context UriInfo uriInfo, @Context HttpServletRequest servletRequest)
+			throws UnknownCollectionId, UnknownDatasetId, InvalidParameterValue {
 		RequestedMediaType requestedMediaType = new RequestedMediaType(format, XML, APPLICATION_XML);
-		return collection(datasetId, collectionId, uriInfo, requestedMediaType);
+		return collection(datasetId, collectionId, uriInfo, servletRequest, requestedMediaType);
 	}
 
 	@GET
@@ -110,9 +113,10 @@ public class FeatureCollection {
 			@PathParam("collectionId") String collectionId,
 			@Parameter(description = "The request output format.", style = ParameterStyle.FORM,
 					schema = @Schema(allowableValues = { "json", "html", "xml" })) @QueryParam("f") String format,
-			@Context UriInfo uriInfo) throws UnknownCollectionId, InvalidParameterValue, UnknownDatasetId {
+			@Context UriInfo uriInfo, @Context HttpServletRequest servletRequest)
+			throws UnknownCollectionId, InvalidParameterValue, UnknownDatasetId {
 		RequestedMediaType requestedMediaType = new RequestedMediaType(format, HTML, TEXT_HTML);
-		return collection(datasetId, collectionId, uriInfo, requestedMediaType);
+		return collection(datasetId, collectionId, uriInfo, servletRequest, requestedMediaType);
 	}
 
 	@GET
@@ -121,20 +125,22 @@ public class FeatureCollection {
 			@PathParam("collectionId") String collectionId,
 			@Parameter(description = "The request output format.", style = ParameterStyle.FORM,
 					schema = @Schema(allowableValues = { "json", "html", "xml" })) @QueryParam("f") String format,
-			@Context UriInfo uriInfo) throws UnknownCollectionId, InvalidParameterValue, UnknownDatasetId {
+			@Context UriInfo uriInfo, @Context HttpServletRequest servletRequest)
+			throws UnknownCollectionId, InvalidParameterValue, UnknownDatasetId {
 		RequestedMediaType requestedMediaType = new RequestedMediaType(format, JSON, APPLICATION_JSON);
-		return collection(datasetId, collectionId, uriInfo, requestedMediaType);
+		return collection(datasetId, collectionId, uriInfo, servletRequest, requestedMediaType);
 	}
 
 	private Response collection(String datasetId, String collectionId, UriInfo uriInfo,
-			RequestedMediaType requestedMediaTyp) throws UnknownCollectionId, UnknownDatasetId, InvalidParameterValue {
+			HttpServletRequest servletRequest, RequestedMediaType requestedMediaTyp)
+			throws UnknownCollectionId, UnknownDatasetId, InvalidParameterValue {
 		RequestFormat requestFormat = requestedMediaTyp.getRequestFormat();
 		OafDatasetConfiguration oafConfiguration = deegreeWorkspaceInitializer.getOafDatasets().getDataset(datasetId);
 		oafConfiguration.checkCollection(collectionId);
 		if (HTML.equals(requestFormat)) {
 			return Response.ok(getClass().getResourceAsStream("/collection.html"), TEXT_HTML).build();
 		}
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo, requestedMediaTyp.getSelfMediaType());
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo, servletRequest, requestedMediaTyp.getSelfMediaType());
 		Collection collection = dataAccess.createCollection(oafConfiguration, collectionId, linkBuilder);
 		addAdditionalCollectionLinks(datasetId, collection);
 

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/FeatureCollections.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/FeatureCollections.java
@@ -40,6 +40,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -85,9 +86,10 @@ public class FeatureCollections {
 	public Response collectionsJson(@PathParam("datasetId") String datasetId,
 			@Parameter(description = "The request output format.", style = ParameterStyle.FORM,
 					schema = @Schema(allowableValues = { "json", "html", "xml" })) @QueryParam("f") String format,
-			@Context UriInfo uriInfo) throws UnknownDatasetId, InvalidParameterValue {
+			@Context UriInfo uriInfo, @Context HttpServletRequest servletRequest)
+			throws UnknownDatasetId, InvalidParameterValue {
 		RequestedMediaType requestedMediaType = new RequestedMediaType(format, JSON, APPLICATION_JSON);
-		return collections(datasetId, uriInfo, requestedMediaType);
+		return collections(datasetId, uriInfo, servletRequest, requestedMediaType);
 	}
 
 	@GET
@@ -96,41 +98,44 @@ public class FeatureCollections {
 	public Response collectionsXml(@PathParam("datasetId") String datasetId,
 			@Parameter(description = "The request output format.", style = ParameterStyle.FORM,
 					schema = @Schema(allowableValues = { "json", "html", "xml" })) @QueryParam("f") String format,
-			@Context UriInfo uriInfo) throws UnknownDatasetId, InvalidParameterValue {
+			@Context UriInfo uriInfo, @Context HttpServletRequest servletRequest)
+			throws UnknownDatasetId, InvalidParameterValue {
 		RequestedMediaType requestedMediaType = new RequestedMediaType(format, XML, APPLICATION_XML);
-		return collections(datasetId, uriInfo, requestedMediaType);
+		return collections(datasetId, uriInfo, servletRequest, requestedMediaType);
 	}
 
 	@GET
 	@Produces({ TEXT_HTML })
 	@Operation(hidden = true)
 	public Response collectionsHtml(@PathParam("datasetId") String datasetId, @Context UriInfo uriInfo,
+			@Context HttpServletRequest servletRequest,
 			@Parameter(description = "The request output format.", style = ParameterStyle.FORM,
 					schema = @Schema(allowableValues = { "json", "html", "xml" })) @QueryParam("f") String format)
 			throws UnknownDatasetId, InvalidParameterValue {
 		RequestedMediaType requestedMediaType = new RequestedMediaType(format, HTML, TEXT_HTML);
-		return collections(datasetId, uriInfo, requestedMediaType);
+		return collections(datasetId, uriInfo, servletRequest, requestedMediaType);
 	}
 
 	@GET
 	@Operation(hidden = true)
 	public Response collectionsOther(@PathParam("datasetId") String datasetId, @Context UriInfo uriInfo,
+			@Context HttpServletRequest servletRequest,
 			@Parameter(description = "The request output format.", style = ParameterStyle.FORM,
 					schema = @Schema(allowableValues = { "json", "html", "xml" })) @QueryParam("f") String format)
 			throws UnknownDatasetId, InvalidParameterValue {
 		RequestedMediaType requestedMediaType = new RequestedMediaType(format, JSON, APPLICATION_JSON);
-		return collections(datasetId, uriInfo, requestedMediaType);
+		return collections(datasetId, uriInfo, servletRequest, requestedMediaType);
 	}
 
-	private Response collections(String datasetId, UriInfo uriInfo, RequestedMediaType requestedMediaTyp)
-			throws UnknownDatasetId, InvalidParameterValue {
+	private Response collections(String datasetId, UriInfo uriInfo, HttpServletRequest servletRequest,
+			RequestedMediaType requestedMediaTyp) throws UnknownDatasetId, InvalidParameterValue {
 		RequestFormat requestFormat = requestedMediaTyp.getRequestFormat();
 		OafDatasetConfiguration oafConfiguration = deegreeWorkspaceInitializer.getOafDatasets().getDataset(datasetId);
 		if (HTML.equals(requestFormat)) {
 			return Response.ok(getClass().getResourceAsStream("/collections.html"), TEXT_HTML).build();
 		}
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo, requestedMediaTyp.getSelfMediaType());
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo, servletRequest, requestedMediaTyp.getSelfMediaType());
 		Collections collections = dataAccess.createCollections(oafConfiguration, linkBuilder);
 		addAdditionalCollectionsLinks(datasetId, collections);
 		for (Collection collection : collections.getCollections()) {

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/Features.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/Features.java
@@ -43,6 +43,7 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.Path;
@@ -90,8 +91,8 @@ public class Features {
 	@Operation(operationId = "features", summary = "retrieves features of collection {collectionId}",
 			description = "Retrieves the features of the collection with the id {collectionId}")
 	@Tag(name = "Data")
-	public Response featuresGeoJson(@Context UriInfo uriInfo, @PathParam("datasetId") String datasetId,
-			@PathParam("collectionId") String collectionId,
+	public Response featuresGeoJson(@Context UriInfo uriInfo, @Context HttpServletRequest servletRequest,
+			@PathParam("datasetId") String datasetId, @PathParam("collectionId") String collectionId,
 			@Parameter(
 					description = "Limits the number of items presented in the response document. Ignored if bulk is true.",
 					style = ParameterStyle.FORM,
@@ -130,15 +131,16 @@ public class Features {
 			throws UnknownCollectionId, InternalQueryException, InvalidParameterValue, UnknownDatasetId {
 		RequestedMediaType requestedMediaType = new RequestedMediaType(format, JSON, APPLICATION_GEOJSON,
 				APPLICATION_GEOJSON);
-		return features(uriInfo, datasetId, collectionId, limit, offset, bulk, bbox, bboxCrs, datetime, filter,
-				filterLang, filterCrs, crs, requestedMediaType);
+		return features(uriInfo, servletRequest, datasetId, collectionId, limit, offset, bulk, bbox, bboxCrs, datetime,
+				filter, filterLang, filterCrs, crs, requestedMediaType);
 	}
 
 	@GET
 	@Produces({ APPLICATION_GML, APPLICATION_GML_32, APPLICATION_GML_SF0, APPLICATION_GML_SF2 })
 	@Operation(hidden = true)
-	public Response featuresGml(@Context UriInfo uriInfo, @HeaderParam("Accept") String acceptHeader,
-			@PathParam("datasetId") String datasetId, @PathParam("collectionId") String collectionId,
+	public Response featuresGml(@Context UriInfo uriInfo, @Context HttpServletRequest servletRequest,
+			@HeaderParam("Accept") String acceptHeader, @PathParam("datasetId") String datasetId,
+			@PathParam("collectionId") String collectionId,
 			@Parameter(
 					description = "Limits the number of items presented in the response document. Ignored if bulk=true.",
 					style = ParameterStyle.FORM,
@@ -172,15 +174,15 @@ public class Features {
 					schema = @Schema(allowableValues = { "json", "html", "xml" })) @QueryParam("f") String format)
 			throws UnknownCollectionId, InternalQueryException, InvalidParameterValue, UnknownDatasetId {
 		RequestedMediaType requestedMediaType = new RequestedMediaType(format, XML, acceptHeader, APPLICATION_GML);
-		return features(uriInfo, datasetId, collectionId, limit, offset, bulk, bbox, bboxCrs, datetime, filter,
-				filterLang, filterCrs, crs, requestedMediaType);
+		return features(uriInfo, servletRequest, datasetId, collectionId, limit, offset, bulk, bbox, bboxCrs, datetime,
+				filter, filterLang, filterCrs, crs, requestedMediaType);
 	}
 
 	@GET
 	@Produces({ TEXT_HTML })
 	@Operation(hidden = true)
-	public Response featuresHtml(@Context UriInfo uriInfo, @PathParam("datasetId") String datasetId,
-			@PathParam("collectionId") String collectionId,
+	public Response featuresHtml(@Context UriInfo uriInfo, @Context HttpServletRequest servletRequest,
+			@PathParam("datasetId") String datasetId, @PathParam("collectionId") String collectionId,
 			@Parameter(
 					description = "Limits the number of items presented in the response document. Ignored if bulk=true.",
 					style = ParameterStyle.FORM,
@@ -214,14 +216,14 @@ public class Features {
 					schema = @Schema(allowableValues = { "json", "html", "xml" })) @QueryParam("f") String format)
 			throws InvalidParameterValue, UnknownDatasetId, UnknownCollectionId, InternalQueryException {
 		RequestedMediaType requestedMediaType = new RequestedMediaType(format, HTML, TEXT_HTML, TEXT_HTML);
-		return features(uriInfo, datasetId, collectionId, limit, offset, bulk, bbox, bboxCrs, datetime, filter,
-				filterLang, filterCrs, crs, requestedMediaType);
+		return features(uriInfo, servletRequest, datasetId, collectionId, limit, offset, bulk, bbox, bboxCrs, datetime,
+				filter, filterLang, filterCrs, crs, requestedMediaType);
 	}
 
 	@GET
 	@Operation(hidden = true)
-	public Response featuresOther(@Context UriInfo uriInfo, @PathParam("datasetId") String datasetId,
-			@PathParam("collectionId") String collectionId,
+	public Response featuresOther(@Context UriInfo uriInfo, @Context HttpServletRequest servletRequest,
+			@PathParam("datasetId") String datasetId, @PathParam("collectionId") String collectionId,
 			@Parameter(
 					description = "Limits the number of items presented in the response document. Ignored if bulk=true.",
 					style = ParameterStyle.FORM,
@@ -255,13 +257,13 @@ public class Features {
 					schema = @Schema(allowableValues = { "json", "html", "xml" })) @QueryParam("f") String format)
 			throws InvalidParameterValue, UnknownDatasetId, UnknownCollectionId, InternalQueryException {
 		RequestedMediaType requestedMediaType = new RequestedMediaType(format, HTML, TEXT_HTML, TEXT_HTML);
-		return features(uriInfo, datasetId, collectionId, limit, offset, bulk, bbox, bboxCrs, datetime, filter,
-				filterLang, filterCrs, crs, requestedMediaType);
+		return features(uriInfo, servletRequest, datasetId, collectionId, limit, offset, bulk, bbox, bboxCrs, datetime,
+				filter, filterLang, filterCrs, crs, requestedMediaType);
 	}
 
-	private Response features(UriInfo uriInfo, String datasetId, String collectionId, int limit, int offset,
-			boolean isBulkUpload, List<Double> bbox, String bboxCrs, String datetime, String filter, String filterLang,
-			String filterCrs, String crs, RequestedMediaType requestedMediaType)
+	private Response features(UriInfo uriInfo, HttpServletRequest servletRequest, String datasetId, String collectionId,
+			int limit, int offset, boolean isBulkUpload, List<Double> bbox, String bboxCrs, String datetime,
+			String filter, String filterLang, String filterCrs, String crs, RequestedMediaType requestedMediaType)
 			throws UnknownDatasetId, InvalidParameterValue, UnknownCollectionId, InternalQueryException {
 		FilterLang.fromType(filterLang);
 		RequestFormat requestFormat = requestedMediaType.getRequestFormat();
@@ -283,7 +285,7 @@ public class Features {
 			.withQueryableParameters(filterParameters)
 			.withFilter(filter, filterCrs)
 			.build();
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo, requestedMediaType.getSelfMediaType());
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo, servletRequest, requestedMediaType.getSelfMediaType());
 		FeaturesResponse featureResponse = dataAccess.retrieveFeatures(oafConfiguration, collectionId, featuresRequest,
 				linkBuilder);
 		if (XML.equals(requestFormat)) {

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/LandingPage.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/LandingPage.java
@@ -39,6 +39,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -71,45 +72,46 @@ public class LandingPage {
 	@Tag(name = "Capabilities")
 	@ApiResponse(description = "default response",
 			content = @Content(schema = @Schema(implementation = LandingPage.class)))
-	public Response landingPageJson(@Context UriInfo uriInfo,
+	public Response landingPageJson(@Context UriInfo uriInfo, @Context HttpServletRequest servletRequest,
 			@Parameter(description = "The request output format.", style = ParameterStyle.FORM,
 					schema = @Schema(allowableValues = { "json", "html", "xml" })) @QueryParam("f") String format,
 			@PathParam("datasetId") String datasetId) throws UnknownDatasetId, InvalidParameterValue {
-		return landingPage(uriInfo, datasetId, format, JSON, APPLICATION_JSON);
+		return landingPage(uriInfo, servletRequest, datasetId, format, JSON, APPLICATION_JSON);
 	}
 
 	@GET
 	@Produces({ APPLICATION_XML })
 	@Tag(name = "Capabilities")
 	@Operation(hidden = true)
-	public Response landingPageJsonXml(@Context UriInfo uriInfo,
+	public Response landingPageJsonXml(@Context UriInfo uriInfo, @Context HttpServletRequest servletRequest,
 			@Parameter(description = "The request output format.", style = ParameterStyle.FORM,
 					schema = @Schema(allowableValues = { "json", "html", "xml" })) @QueryParam("f") String format,
 			@PathParam("datasetId") String datasetId) throws UnknownDatasetId, InvalidParameterValue {
-		return landingPage(uriInfo, datasetId, format, XML, APPLICATION_XML);
+		return landingPage(uriInfo, servletRequest, datasetId, format, XML, APPLICATION_XML);
 	}
 
 	@GET
 	@Produces({ TEXT_HTML })
 	@Operation(hidden = true)
-	public Response landingPageHtml(@Context UriInfo uriInfo,
+	public Response landingPageHtml(@Context UriInfo uriInfo, @Context HttpServletRequest servletRequest,
 			@Parameter(description = "The request output format.", style = ParameterStyle.FORM,
 					schema = @Schema(allowableValues = { "json", "html", "xml" })) @QueryParam("f") String format,
 			@PathParam("datasetId") String datasetId) throws UnknownDatasetId, InvalidParameterValue {
-		return landingPage(uriInfo, datasetId, format, HTML, TEXT_HTML);
+		return landingPage(uriInfo, servletRequest, datasetId, format, HTML, TEXT_HTML);
 	}
 
 	@GET
 	@Operation(hidden = true)
-	public Response landingPageOther(@Context UriInfo uriInfo,
+	public Response landingPageOther(@Context UriInfo uriInfo, @Context HttpServletRequest servletRequest,
 			@Parameter(description = "The request output format.", style = ParameterStyle.FORM,
 					schema = @Schema(allowableValues = { "json", "html", "xml" })) @QueryParam("f") String format,
 			@PathParam("datasetId") String datasetId) throws UnknownDatasetId, InvalidParameterValue {
-		return landingPage(uriInfo, datasetId, format, JSON, APPLICATION_JSON);
+		return landingPage(uriInfo, servletRequest, datasetId, format, JSON, APPLICATION_JSON);
 	}
 
-	private Response landingPage(UriInfo uriInfo, String datasetId, String formatParamValue,
-			RequestFormat defaultFormat, String requestedMediaTyp) throws UnknownDatasetId, InvalidParameterValue {
+	private Response landingPage(UriInfo uriInfo, HttpServletRequest servletRequest, String datasetId,
+			String formatParamValue, RequestFormat defaultFormat, String requestedMediaTyp)
+			throws UnknownDatasetId, InvalidParameterValue {
 		OafDatasetConfiguration dataset = deegreeWorkspaceInitializer.getOafDatasets().getDataset(datasetId);
 		RequestFormat requestFormat = byFormatParameter(formatParamValue, defaultFormat);
 		if (HTML.equals(requestFormat)) {
@@ -118,7 +120,7 @@ public class LandingPage {
 
 		DatasetMetadata metadata = dataset.getServiceMetadata();
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo, requestedMediaTyp);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo, servletRequest, requestedMediaTyp);
 		List<Link> links = linkBuilder.createLandingPageLinks(datasetId, metadata);
 		org.deegree.services.oaf.domain.landingpage.LandingPage landingPage = new org.deegree.services.oaf.domain.landingpage.LandingPage(
 				metadata.getTitle(), metadata.getDescription(), links);

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/OpenApi.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/OpenApi.java
@@ -26,6 +26,7 @@ import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.models.OpenAPI;
+import jakarta.servlet.http.HttpServletRequest;
 import org.apache.http.HttpStatus;
 import org.deegree.commons.utils.TunableParameter;
 import org.deegree.services.oaf.openapi.OpenApiCreator;
@@ -79,8 +80,8 @@ public class OpenApi {
 	@Operation(operationId = "openApi", summary = "api documentation", description = "api documentation")
 	@Tag(name = "Capabilities")
 	public Response getOpenApiOpenApiJson(@Context HttpHeaders headers, @Context UriInfo uriInfo,
-			@PathParam("datasetId") String datasetId) throws Exception {
-		return respondWithOpenApi(headers, uriInfo, datasetId, true);
+			@Context HttpServletRequest servletRequest, @PathParam("datasetId") String datasetId) throws Exception {
+		return respondWithOpenApi(headers, uriInfo, servletRequest, datasetId, true);
 	}
 
 	@GET
@@ -88,13 +89,13 @@ public class OpenApi {
 	@Operation(operationId = "openApi", summary = "api documentation", description = "api documentation")
 	@Tag(name = "Capabilities")
 	public Response getOpenApiOpenApiYaml(@Context HttpHeaders headers, @Context UriInfo uriInfo,
-			@PathParam("datasetId") String datasetId) throws Exception {
-		return respondWithOpenApi(headers, uriInfo, datasetId, false);
+			@Context HttpServletRequest servletRequest, @PathParam("datasetId") String datasetId) throws Exception {
+		return respondWithOpenApi(headers, uriInfo, servletRequest, datasetId, false);
 	}
 
-	private Response respondWithOpenApi(HttpHeaders headers, UriInfo uriInfo, String datasetId, boolean json)
-			throws Exception {
-		OpenAPI openApi = this.openApiCreator.createOpenApi(headers, uriInfo, datasetId);
+	private Response respondWithOpenApi(HttpHeaders headers, UriInfo uriInfo, HttpServletRequest servletRequest,
+			String datasetId, boolean json) throws Exception {
+		OpenAPI openApi = this.openApiCreator.createOpenApi(headers, uriInfo, servletRequest, datasetId);
 
 		if (openApi == null)
 			return Response.status(404).build();

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/schema/SchemaResponseGmlWriter.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/schema/SchemaResponseGmlWriter.java
@@ -1,21 +1,9 @@
 package org.deegree.services.oaf.schema;
 
-import org.deegree.feature.types.FeatureType;
-import org.deegree.gml.schema.GMLAppSchemaWriter;
-import org.deegree.gml.schema.GMLSchemaInfoSet;
-import org.deegree.services.oaf.OgcApiFeatures;
-import org.deegree.services.oaf.workspace.DeegreeWorkspaceInitializer;
-import org.slf4j.Logger;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_XML;
+import static org.deegree.gml.GMLVersion.GML_32;
+import static org.slf4j.LoggerFactory.getLogger;
 
-import jakarta.inject.Inject;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.WebApplicationException;
-import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.MultivaluedMap;
-import jakarta.ws.rs.core.UriInfo;
-import jakarta.ws.rs.ext.MessageBodyWriter;
-import jakarta.ws.rs.ext.Provider;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
@@ -25,9 +13,21 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Collections;
 
-import static jakarta.ws.rs.core.MediaType.APPLICATION_XML;
-import static org.deegree.gml.GMLVersion.GML_32;
-import static org.slf4j.LoggerFactory.getLogger;
+import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.UriInfo;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.Provider;
+import org.deegree.feature.types.FeatureType;
+import org.deegree.gml.schema.GMLAppSchemaWriter;
+import org.deegree.gml.schema.GMLSchemaInfoSet;
+import org.deegree.services.oaf.workspace.DeegreeWorkspaceInitializer;
+import org.slf4j.Logger;
 
 /**
  * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
@@ -43,6 +43,9 @@ public class SchemaResponseGmlWriter implements MessageBodyWriter<SchemaResponse
 
 	@Context
 	private UriInfo uriInfo;
+
+	@Context
+	private HttpServletRequest request;
 
 	@Override
 	public boolean isWriteable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
@@ -109,7 +112,7 @@ public class SchemaResponseGmlWriter implements MessageBodyWriter<SchemaResponse
 		String featureTypeNamespaceURI = featureType.getName().getNamespaceURI();
 		GMLSchemaInfoSet gmlSchema = schemaResponse.getGmlSchema();
 		GMLAppSchemaWriter.export(writer, gmlSchema, featureTypeNamespaceURI, uri -> {
-			String appschemaUri = deegreeWorkspaceInitializer.createAppschemaUrl(uriInfo, uri);
+			String appschemaUri = deegreeWorkspaceInitializer.createAppschemaUrl(uriInfo, request, uri);
 			if (appschemaUri != null)
 				return appschemaUri;
 			return uri;

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/schema/SchemaResponseGmlWriter.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/schema/SchemaResponseGmlWriter.java
@@ -1,17 +1,10 @@
 package org.deegree.services.oaf.schema;
 
-import static jakarta.ws.rs.core.MediaType.APPLICATION_XML;
-import static org.deegree.gml.GMLVersion.GML_32;
-import static org.slf4j.LoggerFactory.getLogger;
-
-import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
-import java.util.Collections;
+import org.deegree.feature.types.FeatureType;
+import org.deegree.gml.schema.GMLAppSchemaWriter;
+import org.deegree.gml.schema.GMLSchemaInfoSet;
+import org.deegree.services.oaf.workspace.DeegreeWorkspaceInitializer;
+import org.slf4j.Logger;
 
 import jakarta.inject.Inject;
 import jakarta.servlet.http.HttpServletRequest;
@@ -23,11 +16,18 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.UriInfo;
 import jakarta.ws.rs.ext.MessageBodyWriter;
 import jakarta.ws.rs.ext.Provider;
-import org.deegree.feature.types.FeatureType;
-import org.deegree.gml.schema.GMLAppSchemaWriter;
-import org.deegree.gml.schema.GMLSchemaInfoSet;
-import org.deegree.services.oaf.workspace.DeegreeWorkspaceInitializer;
-import org.slf4j.Logger;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Collections;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_XML;
+import static org.deegree.gml.GMLVersion.GML_32;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/DeegreeWorkspaceInitializer.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/DeegreeWorkspaceInitializer.java
@@ -21,6 +21,7 @@
  */
 package org.deegree.services.oaf.workspace;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.deegree.commons.config.DeegreeWorkspace;
 import org.deegree.services.controller.OGCFrontController;
 import org.deegree.services.oaf.OafResource;
@@ -144,11 +145,11 @@ public class DeegreeWorkspaceInitializer {
 		return additionalCollectionsMap;
 	}
 
-	public String createAppschemaUrl(UriInfo uriInfo, String uri) {
+	public String createAppschemaUrl(UriInfo uriInfo, HttpServletRequest request, String uri) {
 		Path uriPath = Path.of(URI.create(uri));
 		if (uriPath.startsWith(pathToAppschemas)) {
 			Path relativizeUriPath = pathToAppschemas.relativize(uriPath);
-			LinkBuilder linkBuilder = new LinkBuilder(uriInfo);
+			LinkBuilder linkBuilder = new LinkBuilder(uriInfo, request);
 			return linkBuilder.createSchemaLink(relativizeUriPath.toString());
 		}
 		return null;

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/filter/OafOpenApiFilterTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/filter/OafOpenApiFilterTest.java
@@ -50,8 +50,7 @@ import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.parser.OpenAPIV3Parser;
-import jakarta.ws.rs.core.UriBuilder;
-import jakarta.ws.rs.core.UriInfo;
+import org.deegree.services.oaf.link.LinkBuilder;
 import org.deegree.services.oaf.openapi.OafOpenApiFilter;
 import org.deegree.services.oaf.workspace.DeegreeWorkspaceInitializer;
 import org.hamcrest.BaseMatcher;
@@ -69,12 +68,11 @@ class OafOpenApiFilterTest {
 	private static final String BASE_URI = "http://localhost:8081/deegree-services-oaf";
 
 	@Mock
-	static UriInfo uriInfo = mock(UriInfo.class);
+	static LinkBuilder linkBuilder = mock(LinkBuilder.class);
 
 	@BeforeAll
 	static void mockUriInfo() {
-		when(uriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri(BASE_URI), UriBuilder.fromUri(BASE_URI),
-				UriBuilder.fromUri(BASE_URI));
+		when(linkBuilder.createDatasetLinkUrl("oaf")).thenReturn(BASE_URI + "/datasets/oaf");
 	}
 
 	@Test
@@ -85,7 +83,7 @@ class OafOpenApiFilterTest {
 
 		DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = mockWorkspaceInitializer();
 
-		OafOpenApiFilter filter = new OafOpenApiFilter(uriInfo, "oaf", deegreeWorkspaceInitializer);
+		OafOpenApiFilter filter = new OafOpenApiFilter(linkBuilder, "oaf", deegreeWorkspaceInitializer);
 		filter.filterOpenAPI(openAPI, null, null, null);
 
 		Paths paths = openAPI.getPaths();
@@ -136,7 +134,7 @@ class OafOpenApiFilterTest {
 		DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = mockWorkspaceInitializer(
 				new QName("http://www.deegree.org/app", "KitaEinrichtungen"));
 
-		OafOpenApiFilter filter = new OafOpenApiFilter(uriInfo, "oaf", deegreeWorkspaceInitializer);
+		OafOpenApiFilter filter = new OafOpenApiFilter(linkBuilder, "oaf", deegreeWorkspaceInitializer);
 		filter.filterOpenAPI(openAPI, null, null, null);
 
 		Paths paths = openAPI.getPaths();
@@ -177,7 +175,7 @@ class OafOpenApiFilterTest {
 		DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = mockWorkspaceInitializer(
 				new QName("http://www.deegree.org/datasource/feature/sql", "Zuwanderung"));
 
-		OafOpenApiFilter filter = new OafOpenApiFilter(uriInfo, "oaf", deegreeWorkspaceInitializer);
+		OafOpenApiFilter filter = new OafOpenApiFilter(linkBuilder, "oaf", deegreeWorkspaceInitializer);
 		filter.filterOpenAPI(openAPI, null, null, null);
 
 		Paths paths = openAPI.getPaths();

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/link/LinkBuilderTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/link/LinkBuilderTest.java
@@ -15,13 +15,16 @@ import static org.mockito.Mockito.when;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.PathSegment;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.deegree.services.oaf.TestData;
 import org.deegree.services.oaf.workspace.DeegreeWorkspaceInitializer;
 import org.deegree.services.oaf.workspace.configuration.DatasetMetadata;
@@ -42,8 +45,8 @@ class LinkBuilderTest {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections";
 		String path = "datasets/oaf/collections";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), httpRequest(),
-				APPLICATION_JSON);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"),
+				httpRequest("/deegree-services-oaf"), APPLICATION_JSON);
 		DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = TestData.mockWorkspaceInitializer();
 		DatasetMetadata datasetMetadata = deegreeWorkspaceInitializer.getOafDatasets()
 			.getDataset("oaf")
@@ -61,8 +64,8 @@ class LinkBuilderTest {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections";
 		String path = "datasets/oaf/collections";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), httpRequest(),
-				APPLICATION_XML);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"),
+				httpRequest("/deegree-services-oaf"), APPLICATION_XML);
 		DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = TestData.mockWorkspaceInitializer();
 		DatasetMetadata datasetMetadata = deegreeWorkspaceInitializer.getOafDatasets()
 			.getDataset("oaf")
@@ -80,7 +83,8 @@ class LinkBuilderTest {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections";
 		String path = "datasets/oaf/collections";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path), httpRequest(), APPLICATION_JSON);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path), httpRequest("/deegree-services-oaf"),
+				APPLICATION_JSON);
 		List<Link> collectionLinks = linkBuilder.createCollectionLinks("oaf", "strassenbaumkataster",
 				Collections.emptyList());
 
@@ -108,8 +112,8 @@ class LinkBuilderTest {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections/strassenbaumkataster";
 		String path = "datasets/oaf/collections/strassenbaumkataster";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), httpRequest(),
-				APPLICATION_JSON);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"),
+				httpRequest("/deegree-services-oaf"), APPLICATION_JSON);
 		List<Link> collectionLinks = linkBuilder.createCollectionLinks("oaf", "strassenbaumkataster",
 				Collections.emptyList());
 
@@ -136,8 +140,8 @@ class LinkBuilderTest {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections/strassenbaumkataster";
 		String path = "datasets/oaf/collections/strassenbaumkataster";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), httpRequest(),
-				APPLICATION_XML);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"),
+				httpRequest("/deegree-services-oaf"), APPLICATION_XML);
 		List<Link> collectionLinks = linkBuilder.createCollectionLinks("oaf", "strassenbaumkataster",
 				Collections.emptyList());
 
@@ -164,8 +168,8 @@ class LinkBuilderTest {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections/strassenbaumkataster/items";
 		String path = "datasets/oaf/collections/strassenbaumkataster/items";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), httpRequest(),
-				APPLICATION_GEOJSON);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"),
+				httpRequest("/deegree-services-oaf"), APPLICATION_GEOJSON);
 		NextLink nextLink = new NextLink(1000, 10, 0);
 		List<Link> featuresLinks = linkBuilder.createFeaturesLinks("oaf", "strassenbaumkataster", nextLink);
 
@@ -189,8 +193,8 @@ class LinkBuilderTest {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections/strassenbaumkataster/items";
 		String path = "datasets/oaf/collections/strassenbaumkataster/items";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), httpRequest(),
-				APPLICATION_GML);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"),
+				httpRequest("/deegree-services-oaf"), APPLICATION_GML);
 		NextLink nextLink = new NextLink(1000, 10, 0);
 		List<Link> featuresLinks = linkBuilder.createFeaturesLinks("oaf", "strassenbaumkataster", nextLink);
 
@@ -214,8 +218,8 @@ class LinkBuilderTest {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections/strassenbaumkataster/items?offset=10&limit=10";
 		String path = "datasets/oaf/collections/strassenbaumkataster/items";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), httpRequest(),
-				APPLICATION_GEOJSON);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"),
+				httpRequest("/deegree-services-oaf"), APPLICATION_GEOJSON);
 		NextLink nextLink = new NextLink(1000, 10, 10);
 		List<Link> featuresLinks = linkBuilder.createFeaturesLinks("oaf", "strassenbaumkataster", nextLink);
 
@@ -240,8 +244,8 @@ class LinkBuilderTest {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections/strassenbaumkataster/items";
 		String path = "datasets/oaf/collections/strassenbaumkataster/items";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), httpRequest(),
-				APPLICATION_GEOJSON);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"),
+				httpRequest("/deegree-services-oaf"), APPLICATION_GEOJSON);
 		List<Link> featureLinks = linkBuilder.createFeatureLinks("oaf", "strassenbaumkataster");
 
 		assertThat(featureLinks.size(), is(9));
@@ -263,8 +267,8 @@ class LinkBuilderTest {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections/strassenbaumkataster/items";
 		String path = "datasets/oaf/collections/strassenbaumkataster/items";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), httpRequest(),
-				APPLICATION_GML_32);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"),
+				httpRequest("/deegree-services-oaf"), APPLICATION_GML_32);
 		List<Link> featureLinks = linkBuilder.createFeatureLinks("oaf", "strassenbaumkataster");
 
 		assertThat(featureLinks.size(), is(9));
@@ -286,7 +290,8 @@ class LinkBuilderTest {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections/strassenbaumkataster/appschema";
 		String path = "datasets/oaf/collections/strassenbaumkataster/appschema";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path), httpRequest(), APPLICATION_JSON);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path), httpRequest("/deegree-services-oaf"),
+				APPLICATION_JSON);
 		String schemaLink = linkBuilder.createSchemaLink("oaf", "otherFeatureType");
 
 		assertThat(schemaLink,
@@ -299,7 +304,7 @@ class LinkBuilderTest {
 		String path = "datasets/oaf/collections";
 
 		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"),
-				httpRequest("https", "example.org", "7077"), APPLICATION_JSON);
+				httpRequest("https", "example.org", "7077", "/deegree-services-oaf"), APPLICATION_JSON);
 		DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = TestData.mockWorkspaceInitializer();
 		DatasetMetadata datasetMetadata = deegreeWorkspaceInitializer.getOafDatasets()
 			.getDataset("oaf")
@@ -320,7 +325,7 @@ class LinkBuilderTest {
 		String path = "datasets/oaf/collections";
 
 		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"),
-				httpRequest(null, "example.org", null), APPLICATION_JSON);
+				httpRequest(null, "example.org", null, "/deegree-services-oaf"), APPLICATION_JSON);
 		DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = TestData.mockWorkspaceInitializer();
 		DatasetMetadata datasetMetadata = deegreeWorkspaceInitializer.getOafDatasets()
 			.getDataset("oaf")
@@ -336,12 +341,54 @@ class LinkBuilderTest {
 	}
 
 	@Test
+	void create_links_xForwardedHostWithContextPath() throws Exception {
+		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections";
+		String path = "datasets/oaf/collections";
+
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"),
+				httpRequest(null, "example.org", null, "ogc-api", "/deegree-services-oaf"), APPLICATION_JSON);
+		DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = TestData.mockWorkspaceInitializer();
+		DatasetMetadata datasetMetadata = deegreeWorkspaceInitializer.getOafDatasets()
+			.getDataset("oaf")
+			.getServiceMetadata();
+		List<Link> collectionsLinks = linkBuilder.createCollectionsLinks("oaf", datasetMetadata);
+
+		String expectedUri = "http://example.org:8081/ogc-api/datasets/oaf/collections";
+
+		assertThat(collectionsLinks.size(), is(3));
+		assertThat(collectionsLinks, hasLinkWith("self", APPLICATION_JSON, expectedUri));
+		assertThat(collectionsLinks, hasLinkWith("alternate", APPLICATION_XML, expectedUri));
+		assertThat(collectionsLinks, hasLinkWith("alternate", TEXT_HTML, expectedUri));
+	}
+
+	@Test
+	void create_links_xForwardedHostWithEmptyContextPath() throws Exception {
+		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections";
+		String path = "datasets/oaf/collections";
+
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"),
+				httpRequest(null, "example.org", null, "", "/deegree-services-oaf"), APPLICATION_JSON);
+		DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = TestData.mockWorkspaceInitializer();
+		DatasetMetadata datasetMetadata = deegreeWorkspaceInitializer.getOafDatasets()
+			.getDataset("oaf")
+			.getServiceMetadata();
+		List<Link> collectionsLinks = linkBuilder.createCollectionsLinks("oaf", datasetMetadata);
+
+		String expectedUri = "http://example.org:8081/datasets/oaf/collections";
+
+		assertThat(collectionsLinks.size(), is(3));
+		assertThat(collectionsLinks, hasLinkWith("self", APPLICATION_JSON, expectedUri));
+		assertThat(collectionsLinks, hasLinkWith("alternate", APPLICATION_XML, expectedUri));
+		assertThat(collectionsLinks, hasLinkWith("alternate", TEXT_HTML, expectedUri));
+	}
+
+	@Test
 	void create_links_xForwardedPort() throws Exception {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections";
 		String path = "datasets/oaf/collections";
 
 		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"),
-				httpRequest(null, null, "7077"), APPLICATION_JSON);
+				httpRequest(null, null, "7077", "/deegree-services-oaf"), APPLICATION_JSON);
 		DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = TestData.mockWorkspaceInitializer();
 		DatasetMetadata datasetMetadata = deegreeWorkspaceInitializer.getOafDatasets()
 			.getDataset("oaf")
@@ -362,7 +409,7 @@ class LinkBuilderTest {
 		String path = "datasets/oaf/collections";
 
 		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"),
-				httpRequest("https", null, null), APPLICATION_JSON);
+				httpRequest("https", null, null, "/deegree-services-oaf"), APPLICATION_JSON);
 		DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = TestData.mockWorkspaceInitializer();
 		DatasetMetadata datasetMetadata = deegreeWorkspaceInitializer.getOafDatasets()
 			.getDataset("oaf")
@@ -383,7 +430,7 @@ class LinkBuilderTest {
 		String path = "datasets/oaf/collections";
 
 		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"),
-				httpRequest("https", "example.org:7077", null), APPLICATION_JSON);
+				httpRequest("https", "example.org:7077", null, "/deegree-services-oaf"), APPLICATION_JSON);
 		DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = TestData.mockWorkspaceInitializer();
 		DatasetMetadata datasetMetadata = deegreeWorkspaceInitializer.getOafDatasets()
 			.getDataset("oaf")
@@ -405,6 +452,8 @@ class LinkBuilderTest {
 	private UriInfo uriInfo(String uri, String path, String collectionId) throws URISyntaxException {
 		UriInfo uriInfo = mock(UriInfo.class);
 		when(uriInfo.getPath()).thenReturn(path);
+		when(uriInfo.getPathSegments()).thenReturn(
+				Arrays.stream(path.split("/")).toList().stream().map(LinkBuilderTest::createPathSegment).toList());
 		MultivaluedMap<String, String> pathParameters = new StringKeyIgnoreCaseMultivaluedMap<>();
 		if (collectionId != null)
 			pathParameters.add("collectionId", collectionId);
@@ -418,15 +467,44 @@ class LinkBuilderTest {
 		return uriInfo;
 	}
 
-	private HttpServletRequest httpRequest() {
-		return mock(HttpServletRequest.class);
+	private static @NonNull PathSegment createPathSegment(String p) {
+		return new PathSegment() {
+			@Override
+			public String getPath() {
+				return p;
+			}
+
+			@Override
+			public MultivaluedMap<String, String> getMatrixParameters() {
+				return null;
+			}
+		};
 	}
 
-	private HttpServletRequest httpRequest(String xForwardedProto, String xForwardedHost, String xForwardedPort) {
+	private HttpServletRequest httpRequest(String oldContextPath) {
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		when(request.getContextPath()).thenReturn(oldContextPath);
+		return request;
+	}
+
+	private HttpServletRequest httpRequest(String xForwardedProto, String xForwardedHost, String xForwardedPort,
+			String oldContextPath) {
 		HttpServletRequest request = mock(HttpServletRequest.class);
 		when(request.getHeader("X-Forwarded-Proto")).thenReturn(xForwardedProto);
 		when(request.getHeader("X-Forwarded-Host")).thenReturn(xForwardedHost);
 		when(request.getHeader("X-Forwarded-Port")).thenReturn(xForwardedPort);
+		when(request.getContextPath()).thenReturn(oldContextPath);
+		return request;
+	}
+
+	private HttpServletRequest httpRequest(String xForwardedProto, String xForwardedHost, String xForwardedPort,
+			String xForwardedPrefix, String oldContextPath) {
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		when(request.getHeader("X-Forwarded-Proto")).thenReturn(xForwardedProto);
+		when(request.getHeader("X-Forwarded-Host")).thenReturn(xForwardedHost);
+		when(request.getHeader("X-Forwarded-Port")).thenReturn(xForwardedPort);
+		when(request.getHeader("X-Forwarded-Prefix")).thenReturn(xForwardedPrefix);
+		when(request.getContextPath()).thenReturn(oldContextPath);
 		return request;
 	}
 

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/link/LinkBuilderTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/link/LinkBuilderTest.java
@@ -18,6 +18,7 @@ import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
@@ -41,7 +42,8 @@ class LinkBuilderTest {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections";
 		String path = "datasets/oaf/collections";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), APPLICATION_JSON);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), httpRequest(),
+				APPLICATION_JSON);
 		DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = TestData.mockWorkspaceInitializer();
 		DatasetMetadata datasetMetadata = deegreeWorkspaceInitializer.getOafDatasets()
 			.getDataset("oaf")
@@ -59,7 +61,8 @@ class LinkBuilderTest {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections";
 		String path = "datasets/oaf/collections";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), APPLICATION_XML);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), httpRequest(),
+				APPLICATION_XML);
 		DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = TestData.mockWorkspaceInitializer();
 		DatasetMetadata datasetMetadata = deegreeWorkspaceInitializer.getOafDatasets()
 			.getDataset("oaf")
@@ -77,7 +80,7 @@ class LinkBuilderTest {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections";
 		String path = "datasets/oaf/collections";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path), APPLICATION_JSON);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path), httpRequest(), APPLICATION_JSON);
 		List<Link> collectionLinks = linkBuilder.createCollectionLinks("oaf", "strassenbaumkataster",
 				Collections.emptyList());
 
@@ -105,7 +108,8 @@ class LinkBuilderTest {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections/strassenbaumkataster";
 		String path = "datasets/oaf/collections/strassenbaumkataster";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), APPLICATION_JSON);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), httpRequest(),
+				APPLICATION_JSON);
 		List<Link> collectionLinks = linkBuilder.createCollectionLinks("oaf", "strassenbaumkataster",
 				Collections.emptyList());
 
@@ -127,11 +131,13 @@ class LinkBuilderTest {
 		assertThat(collectionLinks, hasLinkWith("enclosure", APPLICATION_XML, enclosureUri));
 	}
 
+	@Test
 	void create_collection_links_self_xml() throws Exception {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections/strassenbaumkataster";
 		String path = "datasets/oaf/collections/strassenbaumkataster";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), APPLICATION_XML);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), httpRequest(),
+				APPLICATION_XML);
 		List<Link> collectionLinks = linkBuilder.createCollectionLinks("oaf", "strassenbaumkataster",
 				Collections.emptyList());
 
@@ -158,7 +164,8 @@ class LinkBuilderTest {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections/strassenbaumkataster/items";
 		String path = "datasets/oaf/collections/strassenbaumkataster/items";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), APPLICATION_GEOJSON);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), httpRequest(),
+				APPLICATION_GEOJSON);
 		NextLink nextLink = new NextLink(1000, 10, 0);
 		List<Link> featuresLinks = linkBuilder.createFeaturesLinks("oaf", "strassenbaumkataster", nextLink);
 
@@ -182,7 +189,8 @@ class LinkBuilderTest {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections/strassenbaumkataster/items";
 		String path = "datasets/oaf/collections/strassenbaumkataster/items";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), APPLICATION_GML);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), httpRequest(),
+				APPLICATION_GML);
 		NextLink nextLink = new NextLink(1000, 10, 0);
 		List<Link> featuresLinks = linkBuilder.createFeaturesLinks("oaf", "strassenbaumkataster", nextLink);
 
@@ -206,7 +214,8 @@ class LinkBuilderTest {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections/strassenbaumkataster/items?offset=10&limit=10";
 		String path = "datasets/oaf/collections/strassenbaumkataster/items";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), APPLICATION_GEOJSON);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), httpRequest(),
+				APPLICATION_GEOJSON);
 		NextLink nextLink = new NextLink(1000, 10, 10);
 		List<Link> featuresLinks = linkBuilder.createFeaturesLinks("oaf", "strassenbaumkataster", nextLink);
 
@@ -231,7 +240,8 @@ class LinkBuilderTest {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections/strassenbaumkataster/items";
 		String path = "datasets/oaf/collections/strassenbaumkataster/items";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), APPLICATION_GEOJSON);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), httpRequest(),
+				APPLICATION_GEOJSON);
 		List<Link> featureLinks = linkBuilder.createFeatureLinks("oaf", "strassenbaumkataster");
 
 		assertThat(featureLinks.size(), is(9));
@@ -253,7 +263,8 @@ class LinkBuilderTest {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections/strassenbaumkataster/items";
 		String path = "datasets/oaf/collections/strassenbaumkataster/items";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), APPLICATION_GML_32);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"), httpRequest(),
+				APPLICATION_GML_32);
 		List<Link> featureLinks = linkBuilder.createFeatureLinks("oaf", "strassenbaumkataster");
 
 		assertThat(featureLinks.size(), is(9));
@@ -275,11 +286,116 @@ class LinkBuilderTest {
 		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections/strassenbaumkataster/appschema";
 		String path = "datasets/oaf/collections/strassenbaumkataster/appschema";
 
-		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path), APPLICATION_JSON);
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path), httpRequest(), APPLICATION_JSON);
 		String schemaLink = linkBuilder.createSchemaLink("oaf", "otherFeatureType");
 
 		assertThat(schemaLink,
 				is("http://localhost:8081/deegree-services-oaf/datasets/oaf/collections/otherFeatureType/appschema"));
+	}
+
+	@Test
+	void create_links_xForwardedHeader() throws Exception {
+		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections";
+		String path = "datasets/oaf/collections";
+
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"),
+				httpRequest("https", "example.org", "7077"), APPLICATION_JSON);
+		DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = TestData.mockWorkspaceInitializer();
+		DatasetMetadata datasetMetadata = deegreeWorkspaceInitializer.getOafDatasets()
+			.getDataset("oaf")
+			.getServiceMetadata();
+		List<Link> collectionsLinks = linkBuilder.createCollectionsLinks("oaf", datasetMetadata);
+
+		String expectedUri = "https://example.org:7077/deegree-services-oaf/datasets/oaf/collections";
+
+		assertThat(collectionsLinks.size(), is(3));
+		assertThat(collectionsLinks, hasLinkWith("self", APPLICATION_JSON, expectedUri));
+		assertThat(collectionsLinks, hasLinkWith("alternate", APPLICATION_XML, expectedUri));
+		assertThat(collectionsLinks, hasLinkWith("alternate", TEXT_HTML, expectedUri));
+	}
+
+	@Test
+	void create_links_xForwardedHost() throws Exception {
+		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections";
+		String path = "datasets/oaf/collections";
+
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"),
+				httpRequest(null, "example.org", null), APPLICATION_JSON);
+		DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = TestData.mockWorkspaceInitializer();
+		DatasetMetadata datasetMetadata = deegreeWorkspaceInitializer.getOafDatasets()
+			.getDataset("oaf")
+			.getServiceMetadata();
+		List<Link> collectionsLinks = linkBuilder.createCollectionsLinks("oaf", datasetMetadata);
+
+		String expectedUri = "http://example.org:8081/deegree-services-oaf/datasets/oaf/collections";
+
+		assertThat(collectionsLinks.size(), is(3));
+		assertThat(collectionsLinks, hasLinkWith("self", APPLICATION_JSON, expectedUri));
+		assertThat(collectionsLinks, hasLinkWith("alternate", APPLICATION_XML, expectedUri));
+		assertThat(collectionsLinks, hasLinkWith("alternate", TEXT_HTML, expectedUri));
+	}
+
+	@Test
+	void create_links_xForwardedPort() throws Exception {
+		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections";
+		String path = "datasets/oaf/collections";
+
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"),
+				httpRequest(null, null, "7077"), APPLICATION_JSON);
+		DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = TestData.mockWorkspaceInitializer();
+		DatasetMetadata datasetMetadata = deegreeWorkspaceInitializer.getOafDatasets()
+			.getDataset("oaf")
+			.getServiceMetadata();
+		List<Link> collectionsLinks = linkBuilder.createCollectionsLinks("oaf", datasetMetadata);
+
+		String expectedUri = "http://localhost:7077/deegree-services-oaf/datasets/oaf/collections";
+
+		assertThat(collectionsLinks.size(), is(3));
+		assertThat(collectionsLinks, hasLinkWith("self", APPLICATION_JSON, expectedUri));
+		assertThat(collectionsLinks, hasLinkWith("alternate", APPLICATION_XML, expectedUri));
+		assertThat(collectionsLinks, hasLinkWith("alternate", TEXT_HTML, expectedUri));
+	}
+
+	@Test
+	void create_links_xForwardedProto() throws Exception {
+		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections";
+		String path = "datasets/oaf/collections";
+
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"),
+				httpRequest("https", null, null), APPLICATION_JSON);
+		DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = TestData.mockWorkspaceInitializer();
+		DatasetMetadata datasetMetadata = deegreeWorkspaceInitializer.getOafDatasets()
+			.getDataset("oaf")
+			.getServiceMetadata();
+		List<Link> collectionsLinks = linkBuilder.createCollectionsLinks("oaf", datasetMetadata);
+
+		String expectedUri = "https://localhost:8081/deegree-services-oaf/datasets/oaf/collections";
+
+		assertThat(collectionsLinks.size(), is(3));
+		assertThat(collectionsLinks, hasLinkWith("self", APPLICATION_JSON, expectedUri));
+		assertThat(collectionsLinks, hasLinkWith("alternate", APPLICATION_XML, expectedUri));
+		assertThat(collectionsLinks, hasLinkWith("alternate", TEXT_HTML, expectedUri));
+	}
+
+	@Test
+	void create_links_xForwardedHostWithPort() throws Exception {
+		String uri = "http://localhost:8081/deegree-services-oaf/datasets/oaf/collections";
+		String path = "datasets/oaf/collections";
+
+		LinkBuilder linkBuilder = new LinkBuilder(uriInfo(uri, path, "strassenbaumkataster"),
+				httpRequest("https", "example.org:7077", null), APPLICATION_JSON);
+		DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = TestData.mockWorkspaceInitializer();
+		DatasetMetadata datasetMetadata = deegreeWorkspaceInitializer.getOafDatasets()
+			.getDataset("oaf")
+			.getServiceMetadata();
+		List<Link> collectionsLinks = linkBuilder.createCollectionsLinks("oaf", datasetMetadata);
+
+		String expectedUri = "https://example.org:7077/deegree-services-oaf/datasets/oaf/collections";
+
+		assertThat(collectionsLinks.size(), is(3));
+		assertThat(collectionsLinks, hasLinkWith("self", APPLICATION_JSON, expectedUri));
+		assertThat(collectionsLinks, hasLinkWith("alternate", APPLICATION_XML, expectedUri));
+		assertThat(collectionsLinks, hasLinkWith("alternate", TEXT_HTML, expectedUri));
 	}
 
 	private UriInfo uriInfo(String uri, String path) throws URISyntaxException {
@@ -300,6 +416,18 @@ class LinkBuilderTest {
 		UriBuilder requestUriBuilder = UriBuilder.fromUri(new URI(uri));
 		when(uriInfo.getRequestUriBuilder()).thenReturn(requestUriBuilder);
 		return uriInfo;
+	}
+
+	private HttpServletRequest httpRequest() {
+		return mock(HttpServletRequest.class);
+	}
+
+	private HttpServletRequest httpRequest(String xForwardedProto, String xForwardedHost, String xForwardedPort) {
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		when(request.getHeader("X-Forwarded-Proto")).thenReturn(xForwardedProto);
+		when(request.getHeader("X-Forwarded-Host")).thenReturn(xForwardedHost);
+		when(request.getHeader("X-Forwarded-Port")).thenReturn(xForwardedPort);
+		return request;
 	}
 
 	private BaseMatcher<List<Link>> hasLinkWith(String rel, String type, String href) {

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/schema/SchemaResponseGmlWriterTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/schema/SchemaResponseGmlWriterTest.java
@@ -1,5 +1,24 @@
 package org.deegree.services.oaf.schema;
 
+import static org.deegree.gml.GMLVersion.GML_32;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.endsWith;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
+
+import javax.xml.namespace.QName;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.UriInfo;
 import org.apache.commons.io.IOUtils;
 import org.deegree.feature.types.AppSchema;
 import org.deegree.feature.types.FeatureType;
@@ -15,24 +34,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.xmlunit.matchers.EvaluateXPathMatcher;
-
-import jakarta.ws.rs.core.UriInfo;
-import javax.xml.namespace.QName;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.deegree.gml.GMLVersion.GML_32;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.endsWith;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
-import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 
 /**
  * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
@@ -111,10 +112,12 @@ class SchemaResponseGmlWriterTest {
 	private DeegreeWorkspaceInitializer mockWorkspaceInitializer() {
 		DeegreeWorkspaceInitializer deegreeWorkspaceInitializer = mock(DeegreeWorkspaceInitializer.class);
 		lenient()
-			.when(deegreeWorkspaceInitializer.createAppschemaUrl(eq(uriInfo), endsWith("micado_kennzahlen_v1_2.xsd")))
+			.when(deegreeWorkspaceInitializer.createAppschemaUrl(eq(uriInfo), any(HttpServletRequest.class),
+					endsWith("micado_kennzahlen_v1_2.xsd")))
 			.thenReturn("http.//test.de/micado_kennzahlen_v1_2.xsd");
 		lenient()
-			.when(deegreeWorkspaceInitializer.createAppschemaUrl(any(UriInfo.class), endsWith("zeitreihen_v1.xsd")))
+			.when(deegreeWorkspaceInitializer.createAppschemaUrl(any(UriInfo.class), any(HttpServletRequest.class),
+					endsWith("zeitreihen_v1.xsd")))
 			.thenReturn("http.//test.de/zeitreihen_v1.xsd");
 		return deegreeWorkspaceInitializer;
 	}

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/schema/SchemaResponseGmlWriterTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/schema/SchemaResponseGmlWriterTest.java
@@ -1,24 +1,6 @@
 package org.deegree.services.oaf.schema;
 
-import static org.deegree.gml.GMLVersion.GML_32;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.endsWith;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
-import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
-
-import javax.xml.namespace.QName;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
-
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.ws.rs.core.UriInfo;
 import org.apache.commons.io.IOUtils;
 import org.deegree.feature.types.AppSchema;
 import org.deegree.feature.types.FeatureType;
@@ -34,6 +16,24 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.xmlunit.matchers.EvaluateXPathMatcher;
+
+import jakarta.ws.rs.core.UriInfo;
+import javax.xml.namespace.QName;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.deegree.gml.GMLVersion.GML_32;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.endsWith;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 
 /**
  * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>


### PR DESCRIPTION
By default, deegree derives URLs in headers and responses  from the incoming request. When using deegree ogcapi behind a proxy or load balancer, it can be required to override these URLs. This PR enables overwriting the URLs by using the X-Forwarded HTTP Header:
* `X-Forwarded-Host`
* `X-Forwarded-Port`
* `X-Forwarded-Proto`
* `X-Forwarded-Prefix`: overwrites the context path. If sent but empty, the context path will be removed

Futher information how the header is used:    
- `X-Forwarded-Prefix` is used in [Spring Gateway](https://docs.spring.io/spring-cloud-gateway/reference/spring-cloud-gateway-server-webflux/httpheadersfilters.html)

