### PR TITLE
Updated org.webjars:swagger-ui to version 5.32.5

### DIFF
--- a/deegree-ogcapi-webapp/pom.xml
+++ b/deegree-ogcapi-webapp/pom.xml
@@ -120,35 +120,50 @@
           <artifactId>replacer</artifactId>
           <executions>
             <execution>
+              <id>replace-index-html</id>
               <phase>prepare-package</phase>
               <goals>
                 <goal>replace</goal>
               </goals>
+              <configuration>
+                <file>
+                  ${project.build.directory}/swagger-ui/META-INF/resources/webjars/swagger-ui/${swagger-ui-version}/index.html
+                </file>
+                <replacements>
+                  <replacement>
+                    <token>href="./</token>
+                    <value>href="./api/</value>
+                  </replacement>
+                  <replacement>
+                    <token>src="./</token>
+                    <value>src="./api/</value>
+                  </replacement>
+                </replacements>
+              </configuration>
+            </execution>
+            <execution>
+              <id>replace-swagger-initializer</id>
+              <phase>prepare-package</phase>
+              <goals>
+                <goal>replace</goal>
+              </goals>
+              <configuration>
+                <file>
+                  ${project.build.directory}/swagger-ui/META-INF/resources/webjars/swagger-ui/${swagger-ui-version}/swagger-initializer.js
+                </file>
+                <replacements>
+                  <replacement>
+                    <token>url:</token>
+                    <value>requestInterceptor: function (req) {if (req.href == window.location.href) { req.headers = {'Accept': 'application/vnd.oai.openapi+json;version=3.0'};}; return req;}, url:</value>
+                  </replacement>
+                  <replacement>
+                    <token>"https://petstore.swagger.io/v2/swagger.json"</token>
+                    <value>window.location.href</value>
+                  </replacement>
+                </replacements>
+              </configuration>
             </execution>
           </executions>
-          <configuration>
-            <file>
-              ${project.build.directory}/swagger-ui/META-INF/resources/webjars/swagger-ui/${swagger-ui-version}/index.html
-            </file>
-            <replacements>
-              <replacement>
-                <token>url:</token>
-                <value>requestInterceptor: function (req) {if (req.href == window.location.href) { req.headers = {'Accept': 'application/vnd.oai.openapi+json;version=3.0'};}; return req;}, url:</value>
-              </replacement>
-              <replacement>
-                <token>"https://petstore.swagger.io/v2/swagger.json"</token>
-                <value>window.location.href</value>
-              </replacement>
-              <replacement>
-                <token>href="./</token>
-                <value>href="./api/</value>
-              </replacement>
-              <replacement>
-                <token>src="./</token>
-                <value>src="./api/</value>
-              </replacement>
-            </replacements>
-          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -938,7 +938,7 @@
     <site.dir>${user.home}/Sites</site.dir>
     <jersey-version>3.1.11</jersey-version>
     <swagger-version>2.2.41</swagger-version>
-    <swagger-ui-version>3.52.5</swagger-ui-version>
+    <swagger-ui-version>5.32.5</swagger-ui-version>
     <jackson-version>2.16.2</jackson-version>
     <deegree-version>3.6.7</deegree-version>
     <slf4j.version>2.0.17</slf4j.version>


### PR DESCRIPTION
This PR updates the Swagger UI to the recent version. 
Swagger UI provides a web UI which supports the user testing the OpenAPI as documented in https://github.com/lat-lon/deegree-ogcapi/blob/main/deegree-ogcapi-documentation/src/main/asciidoc/usage.adoc#making-a-request