### PR TITLE
Upgraded github actions checkout and setup-java to latest versions

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         version: [ "1.3.9", "2.0.5" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub

--- a/.github/workflows/build_maven.yml
+++ b/.github/workflows/build_maven.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: temurin


### PR DESCRIPTION
This PR updates the GH action to the latest version, upgrade is required till 2nd of June.