### PR TITLE
Upgraded dependency deegree to 3.6.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -940,7 +940,7 @@
     <swagger-version>2.2.48</swagger-version>
     <swagger-ui-version>5.32.5</swagger-ui-version>
     <jackson-version>2.16.2</jackson-version>
-    <deegree-version>3.6.8</deegree-version>
+    <deegree-version>3.6.10</deegree-version>
     <slf4j.version>2.0.17</slf4j.version>
     <logback.version>1.5.19</logback.version>
     <antlr.version>4.13.2</antlr.version>


### PR DESCRIPTION
This PR upgrades deegree core API to v3.6.10 to resolve security issues