### PR TITLE
Adds version 1.3.10 to matrix build in GH action

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [ "1.3.9", "2.0.6" ]
+        version: [ "1.3.10", "2.0.6" ]
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-qemu-action@v3

--- a/docker/1.3/Dockerfile
+++ b/docker/1.3/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG=en_US.UTF-8
 
 # add build info labels that can be set on build
 # see also https://github.com/opencontainers/image-spec/blob/master/annotations.md
-ARG DEEGREE_VERSION=1.3.9
+ARG DEEGREE_VERSION=1.3.10
 ARG DIALECT=postgres
 ARG BUILD_DATE
 ARG VCS_REF


### PR DESCRIPTION
This enables the matrix build on `main` branch for old version 1.3.10 to push docker image to registry.

This replaces the changes made on branch https://github.com/deegree/deegree-ogcapi/tree/1.3-main with commit https://github.com/deegree/deegree-ogcapi/commit/eef93747351c0c289e9cc097050a25810aaa1557 and https://github.com/deegree/deegree-ogcapi/commit/66f946a91aaf79262d805abce5d330972a15abfa